### PR TITLE
Bug Fix | Skip `targetRevision` replacement when chart is specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "argocd-diff-preview"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "base64",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argocd-diff-preview"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -100,6 +100,9 @@ async fn patch_argocd_applications(
 
     let redirect_sources = |file: &str, spec: &mut Mapping| {
         if spec.contains_key("source") {
+            if spec["source"]["chart"].as_str().is_some() {
+                return;
+            }
             match spec["source"]["repoURL"].as_str() {
                 Some(url) if url.contains(repo) => {
                     spec["source"]["targetRevision"] = serde_yaml::Value::String(branch.to_string())
@@ -109,6 +112,9 @@ async fn patch_argocd_applications(
         } else if spec.contains_key("sources") {
             if let Some(sources) = spec["sources"].as_sequence_mut() {
                 for source in sources {
+                    if source["chart"].as_str().is_some() {
+                        continue;
+                    }
                     match source["repoURL"].as_str() {
                         Some(url) if url.contains(repo) => {
                             source["targetRevision"] =


### PR DESCRIPTION
Attempt at fixing this issue: https://github.com/dag-andersen/argocd-diff-preview/issues/33