### PR TITLE
Fix "connection refused" errors when logging in with the argocd cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "argocd-diff-preview"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "base64",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argocd-diff-preview"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile_AMD64
+++ b/Dockerfile_AMD64
@@ -17,7 +17,7 @@ COPY ./src ./src
 
 # install kind
 RUN apt-get update && apt-get install -y curl
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
 RUN chmod +x ./kind
 
 # Install kubectl

--- a/Dockerfile_ARM64
+++ b/Dockerfile_ARM64
@@ -17,7 +17,7 @@ COPY ./src ./src
 
 # install kind
 RUN apt-get update && apt-get install -y curl
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-arm64
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-arm64
 RUN chmod +x ./kind
 
 # Install kubectl

--- a/src/argocd.rs
+++ b/src/argocd.rs
@@ -100,7 +100,9 @@ pub async fn install_argo_cd(options: ArgoCDOptions<'_>) -> Result<(), Box<dyn E
     run_command(
         "kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=300s",
         None,
-    ).await.expect("failed to wait for argocd-server");
+    )
+    .await
+    .expect("failed to wait for argocd-server");
 
     info!("🦑 Argo CD is now available");
 

--- a/src/argocd.rs
+++ b/src/argocd.rs
@@ -95,6 +95,14 @@ pub async fn install_argo_cd(options: ArgoCDOptions<'_>) -> Result<(), Box<dyn E
     .await
     .expect("Failed to wait for argocd-repo-server");
 
+    // wait for argocd-server to be ready
+    run_command(
+        "kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=300s",
+        None,
+    ).await.expect("failed to wait for argocd-server");
+
+    info!("🦑 Argo CD is now available");
+
     info!("🦑 Logging in to Argo CD through CLI...");
     debug!("Port-forwarding Argo CD server...");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,7 @@ pub async fn run_command(command: &str, current_dir: Option<&str>) -> Result<Out
     let args = command.split_whitespace().collect::<Vec<&str>>();
     let output = Command::new(args[0])
         .args(&args[1..])
+        .env("ARGOCD_OPTS", "--port-forward --port-forward-namespace=argocd")
         .current_dir(current_dir.unwrap_or("."))
         .output()
         .expect(format!("Failed to execute command: {}", command).as_str());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,10 @@ pub async fn run_command(command: &str, current_dir: Option<&str>) -> Result<Out
     let args = command.split_whitespace().collect::<Vec<&str>>();
     let output = Command::new(args[0])
         .args(&args[1..])
-        .env("ARGOCD_OPTS", "--port-forward --port-forward-namespace=argocd")
+        .env(
+            "ARGOCD_OPTS",
+            "--port-forward --port-forward-namespace=argocd",
+        )
         .current_dir(current_dir.unwrap_or("."))
         .output()
         .expect(format!("Failed to execute command: {}", command).as_str());


### PR DESCRIPTION
Fix errors like this one:
```
thread 'main' panicked at src/argocd.rs:166:6:
failed to login to argocd: Output { status: ExitStatus(unix_wait_status(5120)), stdout: "", stderr: "time=\"2024-08-23T09:00:53Z\" level=fatal msg=\"dial tcp [::1]:8080: connect: connection refused\"\n" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Solution found here [github comment](https://github.com/argoproj/argo-cd/issues/11783#issuecomment-1447552396)