### PR TITLE
Add support for 'changed files' and 'watch-pattern' annotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,11 +85,10 @@ dependencies = [
 
 [[package]]
 name = "argocd-diff-preview"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "base64",
  "env_logger",
- "glob-match",
  "log",
  "regex",
  "schemars",
@@ -224,12 +223,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "glob-match"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ version = "0.0.19"
 dependencies = [
  "base64",
  "env_logger",
+ "glob-match",
  "log",
  "regex",
  "schemars",
@@ -223,6 +224,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "hashbrown"
@@ -533,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "67d42a0bd4ac281beff598909bb56a86acaf979b84483e1c79c10dcaf98f8cf3"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ tokio = {version="1.40.0",features = ["full"]}
 base64 = "0.22.1"
 serde = "1.0.210"
 serde_yaml = "0.9.33"
-serde_json = "1.0.128"
+serde_json = "1.0.131"
 walkdir = "2.5.0"
 schemars = "0.8.21"
 structopt = { version = "0.3" }
 regex = "1.11.0"
 log = "0.4.22"
 env_logger = "0.11.5"
+glob-match = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argocd-diff-preview"
-version = "0.0.19"
+version = "0.0.20"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,4 +17,3 @@ structopt = { version = "0.3" }
 regex = "1.11.0"
 log = "0.4.22"
 env_logger = "0.11.5"
-glob-match = "0.2.1"

--- a/makefile
+++ b/makefile
@@ -16,10 +16,10 @@ local-test-cargo: pull-repostory
 		--repo $(github_org)/$(gitops_repo) \
 		--debug  \
 		-r "$(regex)" \
-		--diff-ignore "$(diff-ignore)" \
+		--diff-ignore "$(diff_ignore)" \
 		--timeout $(timeout) \
 		-l "$(selector)" \
-		--files-changed="$(files-changed)"
+		--files-changed="$(files_changed)"
 
 local-test-docker: pull-repostory
 	docker build . -f $(docker_file) -t image
@@ -35,6 +35,8 @@ local-test-docker: pull-repostory
 		-e TARGET_BRANCH=$(target_branch) \
 		-e REPO=$(github_org)/$(gitops_repo) \
 		-e FILE_REGEX="$(regex)" \
-		-e DIFF_IGNORE="$(diff-ignore)" \
+		-e DIFF_IGNORE="$(diff_ignore)" \
 		-e TIMEOUT=$(timeout) \
+		-e SELECTOR="$(selector)" \
+		-e FILES_CHANGED="$(files_changed)" \
 		image

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ pull-repostory:
 	cd base-branch   && gh repo clone $(github_org)/$(gitops_repo) -- --depth=1 --branch "$(base_branch)"   && cp -r $(gitops_repo)/. . && rm -rf .git && echo "*" > .gitignore && rm -rf $(gitops_repo) && cd -
 	cd target-branch && gh repo clone $(github_org)/$(gitops_repo) -- --depth=1 --branch "$(target_branch)" && cp -r $(gitops_repo)/. . && rm -rf .git && echo "*" > .gitignore && rm -rf $(gitops_repo) && cd -
 
-local-test-cargo: pull-repostory
+run-with-cargo: pull-repostory
 	cargo run -- -b "$(base_branch)" \
 		-t "$(target_branch)" \
 		--repo $(github_org)/$(gitops_repo) \
@@ -21,7 +21,7 @@ local-test-cargo: pull-repostory
 		-l "$(selector)" \
 		--files-changed="$(files_changed)"
 
-local-test-docker: pull-repostory
+run-with-docker: pull-repostory
 	docker build . -f $(docker_file) -t image
 	docker run \
 		--network=host \

--- a/makefile
+++ b/makefile
@@ -11,7 +11,15 @@ pull-repostory:
 	cd target-branch && gh repo clone $(github_org)/$(gitops_repo) -- --depth=1 --branch "$(target_branch)" && cp -r $(gitops_repo)/. . && rm -rf .git && echo "*" > .gitignore && rm -rf $(gitops_repo) && cd -
 
 local-test-cargo: pull-repostory
-	cargo run -- -b "$(base_branch)" -t "$(target_branch)" --repo $(github_org)/$(gitops_repo) -r "$(regex)" --debug --diff-ignore "$(diff-ignore)" --timeout $(timeout) -l "$(selector)"
+	cargo run -- -b "$(base_branch)" \
+		-t "$(target_branch)" \
+		--repo $(github_org)/$(gitops_repo) \
+		--debug  \
+		-r "$(regex)" \
+		--diff-ignore "$(diff-ignore)" \
+		--timeout $(timeout) \
+		-l "$(selector)" \
+		--files-changed="$(files-changed)"
 
 local-test-docker: pull-repostory
 	docker build . -f $(docker_file) -t image

--- a/src/argocd.rs
+++ b/src/argocd.rs
@@ -60,8 +60,6 @@ pub async fn install_argo_cd(options: ArgoCDOptions<'_>) -> Result<(), Box<dyn E
         }
     }
 
-    info!("🦑 Installing Argo CD Helm Chart");
-
     let helm_install_command = format!(
         "helm install argocd argo/argo-cd -n argocd {} {} {}",
         values.unwrap_or_default(),
@@ -121,10 +119,8 @@ pub async fn install_argo_cd(options: ArgoCDOptions<'_>) -> Result<(), Box<dyn E
         let password_decoded = BASE64_STANDARD
             .decode(password_encoded)
             .expect("failed to decode password");
-        let password =
-            String::from_utf8(password_decoded).expect("failed to convert password to string");
 
-        password
+        String::from_utf8(password_decoded).expect("failed to convert password to string")
     };
 
     // sleep for 5 seconds

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -34,7 +34,7 @@ pub async fn get_resources(
     timeout: u64,
     output_folder: &str,
 ) -> Result<(), Box<dyn Error>> {
-    info!("🌚 Getting resources from {}", branch_type);
+    info!("🌚 Getting resources from {}-branch", branch_type);
 
     let app_file = apps_file(branch_type);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // label selectors can be fined in the following format: key1==value1,key2=value2,key3!=value3
-    let selector = opt.selector.map(|s| {
+    let selector = opt.selector.filter(|s| !s.trim().is_empty()).map(|s| {
         let labels: Vec<Selector> = s
             .split(",")
             .filter(|l| !l.trim().is_empty())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crate::utils::{check_if_folder_exists, create_folder_if_not_exists, run_command};
 use log::{debug, error, info};
-use parsing::applications_to_string;
+use parsing::{applications_to_string, GetApplicationOptions};
 use regex::Regex;
 use std::fs;
 use std::path::PathBuf;
@@ -12,10 +12,10 @@ use std::{
 use structopt::StructOpt;
 mod argocd;
 mod diff;
-mod no_apps_found;
 mod extract;
 mod kind;
 mod minikube;
+mod no_apps_found;
 mod parsing;
 mod utils;
 
@@ -316,19 +316,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // remove .git from repo
     let repo = repo.trim_end_matches(".git");
-    let base_apps = parsing::get_applications(
-        BASE_BRANCH_FOLDER,
-        &base_branch_name,
-        &file_regex,
-        &selector,
-        &files_changed,
-        repo,
-    )
-    .await?;
-
-    let target_apps = parsing::get_applications(
-        TARGET_BRANCH_FOLDER,
-        &target_branch_name,
+    let (base_apps, target_apps) = parsing::get_applications_for_both_branches(
+        GetApplicationOptions {
+            directory: BASE_BRANCH_FOLDER,
+            branch: &base_branch_name,
+        },
+        GetApplicationOptions {
+            directory: TARGET_BRANCH_FOLDER,
+            branch: &target_branch_name,
+        },
         &file_regex,
         &selector,
         &files_changed,

--- a/src/no_apps_found.rs
+++ b/src/no_apps_found.rs
@@ -23,7 +23,9 @@ pub async fn write_message(
         (Some(s), Some(f)) => {
             let message = format!(
                 "🔍 Found 0 Applications that matches '{}' and watches these files: '{}'",
-                selector_string(s), f.join(", "));
+                selector_string(s),
+                f.join(", ")
+            );
             print_diff(&message)
         }
         (Some(s), None) => {

--- a/src/no_apps_found.rs
+++ b/src/no_apps_found.rs
@@ -1,0 +1,68 @@
+use log::info;
+use std::error::Error;
+use std::fs;
+
+use crate::Selector;
+
+// Message to show when no applications were found
+
+pub async fn write_message(
+    output_folder: &str,
+    selector: &Option<Vec<Selector>>,
+    changed_files: &Option<Vec<String>>,
+) -> Result<(), Box<dyn Error>> {
+
+    let selector_string = |s: &Vec<Selector>| {
+        s.iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>()
+            .join(",")
+    };
+
+    let markdown = match (selector, changed_files) {
+        (Some(s), Some(f)) => {
+            let message = format!(
+                "🔍 Found 0 Applications that matches '{}' and watches these files: '{}'",
+                selector_string(s), f.join(", "));
+            print_diff(&message)
+        }
+        (Some(s), None) => {
+            let message = format!(
+                "🔍 Found 0 Applications after selecting applications matching '{}'",
+                selector_string(s)
+            );
+            print_diff(&message)
+        }
+        (None, Some(f)) => {
+            let message = format!(
+                "🔍 Found 0 Applications that watched these files: '{}'",
+                f.join(", ")
+            );
+            print_diff(&message)
+        }
+        (None, None) => {
+            let message = "🔍 Found 0 Applications".to_string();
+            print_diff(&message)
+        }
+    };
+
+    let markdown_path = format!("{}/diff.md", output_folder);
+    fs::write(&markdown_path, markdown)?;
+
+    info!("🙏 Please check the {} file for differences", markdown_path);
+
+    Ok(())
+}
+
+const MARKDOWN_TEMPLATE: &str = r#"
+## Argo CD Diff Preview
+
+%message%
+"#;
+
+fn print_diff(message: &str) -> String {
+    MARKDOWN_TEMPLATE
+        .replace("%message%", message)
+        .trim_start()
+        .to_string()
+}

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -259,21 +259,21 @@ fn get_applications(
             });
             if !selected {
                 debug!(
-                    "Ignoring application {:?} due to selector mismatch in file: {}",
+                    "Ignoring application {:?} due to label selector mismatch in file: {}",
                     a.yaml["metadata"]["name"].as_str().unwrap_or("unknown"),
                     a.file_name
                 );
                 return None;
             } else {
                 debug!(
-                    "Selected application {:?} due to selector match in file: {}",
+                    "Selected application {:?} due to label selector match in file: {}",
                     a.yaml["metadata"]["name"].as_str().unwrap_or("unknown"),
                     a.file_name
                 );
             }
         }
 
-        // 
+        // Check watch pattern annotation
         let pattern: Option<Result<Regex, regex::Error>> = a.yaml["metadata"]["annotations"][ANNOTATION_WATCH_PATTERN].as_str().map(Regex::new);
         match (files_changed, pattern) {
             (None, _) => {}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,10 @@ pub async fn run_command(command: &str, current_dir: Option<&str>) -> Result<Out
     run_command_from_list(args, current_dir).await
 }
 
-pub async fn run_command_from_list(command: Vec<&str>, current_dir: Option<&str>) -> Result<Output, Output> {
+pub async fn run_command_from_list(
+    command: Vec<&str>,
+    current_dir: Option<&str>,
+) -> Result<Output, Output> {
     let output = Command::new(command[0])
         .args(&command[1..])
         .env(
@@ -29,7 +32,7 @@ pub async fn run_command_from_list(command: Vec<&str>, current_dir: Option<&str>
         )
         .current_dir(current_dir.unwrap_or("."))
         .output()
-        .expect(format!("Failed to execute command: {}", command.join(" ")).as_str());
+        .unwrap_or_else(|_| panic!("Failed to execute command: {}", command.join(" ")));
 
     if !output.status.success() {
         return Err(output);
@@ -46,5 +49,5 @@ pub fn spawn_command(command: &str, current_dir: Option<&str>) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect(format!("Failed to execute command: {}", command).as_str());
+        .unwrap_or_else(|_| panic!("Failed to execute command: {}", command));
 }


### PR DESCRIPTION
You can specify which applications to render based on the files that have changed in the pull request. This is useful when you want to render only the applications that have changed.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: my-app
  namespace: argocd
  annotations:
    argocd-diff-preview/watch-pattern: "examples/.*"
spec:
  ...
```