### PR TITLE
fix: install argocd before apply secret

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ClusterTool::Minikube => minikube::create_cluster().await?,
     }
 
+    argocd::install_argo_cd(argocd::ArgoCDOptions {
+        version: argocd_version,
+        debug: opt.debug,
+    })
+    .await?;
+
     create_folder_if_not_exists(secrets_folder);
     match apply_folder(secrets_folder) {
         Ok(count) if count > 0 => info!("🤫 Applied {} secrets", count),
@@ -357,12 +363,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             panic!("error: {}", e)
         }
     }
-
-    argocd::install_argo_cd(argocd::ArgoCDOptions {
-        version: argocd_version,
-        debug: opt.debug,
-    })
-    .await?;
 
     fs::write(apps_file(&Branch::Base), applications_to_string(base_apps))?;
     fs::write(


### PR DESCRIPTION
Hi @dag-andersen Thank you for developing a great tool!

I fixed a bug to failed to apply secrets to local cluster.  This error occur when exists secret that retrieve Git repository.
```
[2024-10-26T08:57:36Z INFO  argocd_diff_preview::kind] 🚀 Creating cluster...
[2024-10-26T08:58:13Z INFO  argocd_diff_preview::kind] 🚀 Cluster created successfully
[2024-10-26T08:58:13Z ERROR argocd_diff_preview] ❌ Failed to apply secrets
thread 'main' panicked at src/main.rs:357:13:
```

When applying secrets, `argocd` namespace must be created first. However, the following commit changed the order of these.
https://github.com/dag-andersen/argocd-diff-preview/commit/b7c9b4205f143ce41e00a57c8779f95190d2ffea#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc