### PR TITLE
fix: repoURL matching is case sensitive

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -238,7 +238,7 @@ async fn patch_applications(
                 Some(url) if url.to_lowercase().contains(repo.to_lowercase()) => {
                     spec["source"]["targetRevision"] = serde_yaml::Value::String(branch.to_string())
                 }
-                _ => debug!("Found no 'repoURL' under spec.sources[] in file: {}", file),
+                _ => debug!("Found no 'repoURL' under spec.source in file: {}", file),
             }
         } else if spec.contains_key("sources") {
             if let Some(sources) = spec["sources"].as_sequence_mut() {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -235,7 +235,7 @@ async fn patch_applications(
                 return;
             }
             match spec["source"]["repoURL"].as_str() {
-                Some(url) if url.contains(repo) => {
+                Some(url) if url.to_lowercase().contains(repo.to_lowercase()) => {
                     spec["source"]["targetRevision"] = serde_yaml::Value::String(branch.to_string())
                 }
                 _ => debug!("Found no 'repoURL' under spec.sources[] in file: {}", file),
@@ -247,7 +247,7 @@ async fn patch_applications(
                         continue;
                     }
                     match source["repoURL"].as_str() {
-                        Some(url) if url.contains(repo) => {
+                        Some(url) if url.to_lowercase().contains(repo.to_lowercase()) => {
                             source["targetRevision"] =
                                 serde_yaml::Value::String(branch.to_string());
                         }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -235,7 +235,7 @@ async fn patch_applications(
                 return;
             }
             match spec["source"]["repoURL"].as_str() {
-                Some(url) if url.to_lowercase().contains(repo.to_lowercase()) => {
+                Some(url) if url.to_lowercase().contains(&repo.to_lowercase()) => {
                     spec["source"]["targetRevision"] = serde_yaml::Value::String(branch.to_string())
                 }
                 _ => debug!("Found no 'repoURL' under spec.source in file: {}", file),
@@ -247,7 +247,7 @@ async fn patch_applications(
                         continue;
                     }
                     match source["repoURL"].as_str() {
-                        Some(url) if url.to_lowercase().contains(repo.to_lowercase()) => {
+                        Some(url) if url.to_lowercase().contains(&repo.to_lowercase()) => {
                             source["targetRevision"] =
                                 serde_yaml::Value::String(branch.to_string());
                         }


### PR DESCRIPTION
*this change is currently untested, I plan on conducting a full one soon*

While testing this awesome project in my own repository, I found that using different casing in the application `repoURL` results in a confusing error message printing that the `repoURL` key was missing entirely. We may want to consider printing something more helpful in that case (for example, "Different 'repoURL' under spec.source in file {}")

Additionally, I fixed the debug message printing `spec.sources[]` as the source even when `spec.source` is used, which mislead me at the start. (=> rebase)