### PR TITLE
Read applications from all namespaces 

### DIFF
--- a/argocd-config/values-post.yaml
+++ b/argocd-config/values-post.yaml
@@ -1,0 +1,9 @@
+# Overrides done by argocd-diff-preview
+# These will happen AFTER the values.yaml file is loaded
+notifications:
+  enabled: false
+dex:
+  enabled: false
+configs:
+  params:
+    reposerver.git.request.timeout: "150s"

--- a/argocd-config/values-pre.yaml
+++ b/argocd-config/values-pre.yaml
@@ -1,9 +1,9 @@
 # Overrides done by argocd-diff-preview
-# These will happen after the values.yaml file is loaded
+# These will happen BEFORE the values.yaml file is loaded
 notifications:
   enabled: false
 dex:
   enabled: false
 configs:
   params:
-    reposerver.git.request.timeout: "150s"
+    application.namespaces: "*"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,7 @@ pub fn run_command_in_dir(
     command: &str,
     current_dir: &str,
 ) -> Result<CommandOutput, CommandOutput> {
+    debug!("Running command: {}", command);
     let args = command.split_whitespace().collect::<Vec<&str>>();
     run_command_from_list(args, Some(current_dir), None)
 }


### PR DESCRIPTION
Read applications from all namespaces instead of applying them all to the same namespace. This avoids name conflicts when applying the Applications to the local cluster. 