### PR TITLE
Moved ArgoCD installation to a new namespace

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,5 +1,5 @@
 use crate::error::CommandOutput;
-use crate::utils::run_command;
+use crate::utils::run_command_in_dir;
 use crate::Branch;
 use log::{debug, info};
 use std::error::Error;
@@ -52,7 +52,7 @@ pub fn generate_diff(
     );
 
     let summary_as_string =
-        parse_diff_output(run_command(&summary_diff_command, Some(output_folder)))?;
+        parse_diff_output(run_command_in_dir(&summary_diff_command, output_folder))?;
 
     let diff_command = &format!(
         "git --no-pager diff --no-prefix -U{} --no-index {} {} {}",
@@ -64,7 +64,7 @@ pub fn generate_diff(
 
     debug!("Getting diff with command: {}", diff_command);
 
-    let diff_as_string = parse_diff_output(run_command(diff_command, Some(output_folder)))?;
+    let diff_as_string = parse_diff_output(run_command_in_dir(diff_command, output_folder))?;
 
     let remaining_max_chars =
         max_diff_message_char_count - markdown_template_length() - summary_as_string.len();

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -6,39 +6,33 @@ use log::{debug, error, info};
 use std::error::Error;
 
 pub fn is_installed() -> bool {
-    run_command("which kind", None).is_ok()
+    run_command("which kind").is_ok()
 }
 
 pub fn create_cluster(cluster_name: &str) -> Result<(), Box<dyn Error>> {
     // check if docker is running
-    run_command("docker ps", None).map_err(|o| {
+    run_command("docker ps").map_err(|o| {
         error!("❌ Docker is not running");
         CommandError::new(o)
     })?;
 
     info!("🚀 Creating cluster...");
-    run_command(
-        &format!("kind delete cluster --name {}", cluster_name),
-        None,
-    )
-    .map_err(CommandError::new)?;
+    run_command(&format!("kind delete cluster --name {}", cluster_name))
+        .map_err(CommandError::new)?;
 
-    run_command(
-        &format!("kind create cluster --name {}", cluster_name),
-        None,
-    )
-    .map(|_| {
-        info!("🚀 Cluster created successfully");
-        Ok(())
-    })
-    .map_err(|e| {
-        error!("❌ Failed to create cluster");
-        CommandError::new(e)
-    })?
+    run_command(&format!("kind create cluster --name {}", cluster_name))
+        .map(|_| {
+            info!("🚀 Cluster created successfully");
+            Ok(())
+        })
+        .map_err(|e| {
+            error!("❌ Failed to create cluster");
+            CommandError::new(e)
+        })?
 }
 
 pub fn cluster_exists(cluster_name: &str) -> bool {
-    match run_command("kind get clusters", None) {
+    match run_command("kind get clusters") {
         Ok(o) if o.stdout.trim() == cluster_name => true,
         Ok(o) => {
             debug!("❌ Cluster '{}' not found in: {}", cluster_name, o.stdout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error::Error, io::Write};
 use structopt::StructOpt;
-use utils::{check_if_folder_exists, create_folder_if_not_exists, run_command_from_list};
+use utils::{check_if_folder_exists, create_folder_if_not_exists, run_command, run_command_from_list};
 mod argo_resource;
 mod argocd;
 mod branch;
@@ -401,7 +401,7 @@ fn cleanup_cluster(tool: ClusterTool, cluster_name: &str) {
 }
 
 fn apply_manifest(file_name: &str) -> Result<CommandOutput, CommandOutput> {
-    run_command_from_list(vec!["kubectl", "apply", "-f", file_name], None).map_err(|e| {
+    run_command(&format!("kubectl apply -f {}", file_name)).map_err(|e| {
         error!("❌ Failed to apply manifest: {}", file_name);
         e
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error::Error, io::Write};
 use structopt::StructOpt;
-use utils::{check_if_folder_exists, create_folder_if_not_exists, run_command, run_command_from_list};
+use utils::{check_if_folder_exists, create_folder_if_not_exists, run_command};
 mod argo_resource;
 mod argocd;
 mod branch;
@@ -186,7 +186,6 @@ async fn run() -> Result<(), Box<dyn Error>> {
             .collect()
         });
 
-    // select local cluster tool
     let cluster_tool = &opt.local_cluster_tool;
 
     let repo_regex = Regex::new(r"^[a-zA-Z0-9-]+/[a-zA-Z0-9\._-]+$").unwrap();
@@ -401,9 +400,8 @@ fn cleanup_cluster(tool: ClusterTool, cluster_name: &str) {
 }
 
 fn apply_manifest(file_name: &str) -> Result<CommandOutput, CommandOutput> {
-    run_command(&format!("kubectl apply -f {}", file_name)).map_err(|e| {
+    run_command(&format!("kubectl apply -f {}", file_name)).inspect_err(|e| {
         error!("❌ Failed to apply manifest: {}", file_name);
-        e
     })
 }
 

--- a/src/minikube.rs
+++ b/src/minikube.rs
@@ -6,20 +6,20 @@ use log::{error, info};
 use std::error::Error;
 
 pub fn is_installed() -> bool {
-    run_command("which minikube", None).is_ok()
+    run_command("which minikube").is_ok()
 }
 
 pub fn create_cluster() -> Result<(), Box<dyn Error>> {
     // check if docker is running
-    run_command("docker ps", None).map_err(|o| {
+    run_command("docker ps").map_err(|o| {
         error!("❌ Docker is not running");
         CommandError::new(o)
     })?;
 
     info!("🚀 Creating cluster...");
-    run_command("minikube delete", None).map_err(CommandError::new)?;
+    run_command("minikube delete").map_err(CommandError::new)?;
 
-    run_command("minikube start", None)
+    run_command("minikube start")
         .map(|_| {
             info!("🚀 Cluster created successfully");
             Ok(())
@@ -31,7 +31,7 @@ pub fn create_cluster() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn cluster_exists() -> bool {
-    run_command("minikube status", None).is_ok()
+    run_command("minikube status").is_ok()
 }
 
 pub fn delete_cluster(wait: bool) {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,4 +1,4 @@
-use crate::{argo_resource::ArgoResource, Branch, Selector};
+use crate::{argo_resource::ArgoResource, argocd::ARGO_CD_NAMESPACE, Branch, Selector};
 use log::{debug, info};
 use regex::Regex;
 use serde_yaml::Value;
@@ -195,7 +195,7 @@ fn patch_applications(
         .map(|a| {
             let app_name = a.name.clone();
             let app: Result<ArgoResource, Box<dyn Error>> = a
-                .set_namespace("argocd")
+                .set_namespace(ARGO_CD_NAMESPACE)
                 .remove_sync_policy()
                 .set_project_to_default()
                 .and_then(|a| a.point_destination_to_in_cluster())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,12 +16,17 @@ pub fn check_if_folder_exists(folder_name: &str) -> bool {
     PathBuf::from(folder_name).is_dir()
 }
 
-pub fn run_command(
+pub fn run_command(command: &str) -> Result<CommandOutput, CommandOutput> {
+    let args = command.split_whitespace().collect::<Vec<&str>>();
+    run_command_from_list(args, None)
+}
+
+pub fn run_command_in_dir(
     command: &str,
-    current_dir: Option<&str>,
+    current_dir: &str,
 ) -> Result<CommandOutput, CommandOutput> {
     let args = command.split_whitespace().collect::<Vec<&str>>();
-    run_command_from_list(args, current_dir)
+    run_command_from_list(args, Some(current_dir))
 }
 
 pub fn run_command_from_list(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::process::{Child, Stdio};
 use std::{fs, process::Command};
 
+use crate::argocd::ARGO_CD_NAMESPACE;
 use crate::error::CommandOutput;
 
 pub fn create_folder_if_not_exists(folder_name: &str) -> Result<(), Box<dyn Error>> {
@@ -37,7 +38,7 @@ pub fn run_command_from_list(
         .args(&command[1..])
         .env(
             "ARGOCD_OPTS",
-            "--port-forward --port-forward-namespace=argocd",
+            format!("--port-forward --port-forward-namespace={}", ARGO_CD_NAMESPACE),
         )
         .current_dir(current_dir.unwrap_or("."))
         .output()


### PR DESCRIPTION
This is done to avoid naming conflicts when users render users real ArgoCD configurations.

Example: [GitHub Issue #70](https://github.com/dag-andersen/argocd-diff-preview/issues/70)