### PR TITLE
Example | ApplicationSet Git Generator 

### DIFF
--- a/examples/git-generator/resources/folder3/deployment.yaml
+++ b/examples/git-generator/resources/folder3/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-from-folder-three
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: myapp
+          image: dag-andersen/myapp:latest
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
This example is based on [this ApplicationSet](https://github.com/dag-andersen/argocd-diff-preview/blob/main/examples/git-generator/app/app-set.yaml) that looks at files in `examples/git-generator/resources/**`

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: git-generator-example-appset
  namespace: argocd
spec:
  goTemplate: true
  goTemplateOptions: ["missingkey=error"]
  generators:
    - git:
        repoURL: https://github.com/dag-andersen/argocd-diff-preview.git
        revision: HEAD
        directories:
          - path: examples/git-generator/resources/**
        values:
          name: "{{ index .path.segments 3 }}"
  template:
    metadata:
      name: "{{ .values.name }}"
    spec:
      source:
        repoURL: https://github.com/dag-andersen/argocd-diff-preview.git
        path: "{{ .path.path }}"
      ...
```