### PR TITLE
Logic that waits for ApplicationSet processing before continuing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ secrets/
 output/
 .vscode/
 /values.yaml
+/apps_target_branch.yaml
+/apps_base_branch.yaml
 venv/
 base-branch/
 target-branch/
-temp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,13 +85,12 @@ dependencies = [
 
 [[package]]
 name = "argocd-diff-preview"
-version = "0.0.29"
+version = "0.0.28"
 dependencies = [
  "base64",
  "env_logger",
  "log",
  "once_cell",
- "rand",
  "regex",
  "schemars",
  "serde",
@@ -145,12 +144,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -227,17 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,9 +285,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lock_api"
@@ -395,15 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,36 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -566,18 +509,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -946,24 +889,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argocd-diff-preview"
-version = "0.0.29"
+version = "0.0.28"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tokio = {version="1.42.0",features = ["full"]}
 base64 = "0.22.1"
-serde = "1.0.217"
+serde = "1.0.216"
 serde_yaml = "0.9.33"
 serde_json = "1.0.134"
 walkdir = "2.5.0"
@@ -18,4 +18,3 @@ regex = "1.11.1"
 log = "0.4.22"
 env_logger = "0.11.6"
 once_cell = "1.20.2"
-rand = "0.8.5"

--- a/src/argocd.rs
+++ b/src/argocd.rs
@@ -8,7 +8,7 @@ use serde_yaml::Value;
 use std::error::Error;
 
 pub struct ArgoCDInstallation {
-    pub namespace: String,
+    namespace: String,
     version: Option<String>,
     config_path: String,
 }
@@ -221,9 +221,5 @@ impl ArgoCDInstallation {
 
     pub fn refresh_app(&self, app_name: &str) -> Result<CommandOutput, CommandOutput> {
         self.run_argocd_command(&format!("argocd app get {} --refresh", app_name))
-    }
-
-    pub fn appset_generate(&self, app_set_path: &str) -> Result<CommandOutput, CommandOutput> {
-        self.run_argocd_command(&format!("argocd appset generate {} -o yaml", app_set_path))
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -36,17 +36,12 @@ pub async fn get_resources(
     branch: &Branch,
     timeout: u64,
     output_folder: &str,
-    input_folder: &str,
 ) -> Result<(), Box<dyn Error>> {
     info!("🌚 Getting resources from {}-branch", branch.branch_type);
 
-    let app_file = &format!("{}/{}", input_folder, branch.app_file());
+    let app_file = branch.app_file();
 
-    if fs::metadata(app_file)
-        .inspect_err(|_| error!("❌ File does not exist: {}", app_file))?
-        .len()
-        != 0
-    {
+    if fs::metadata(app_file)?.len() != 0 {
         apply_manifest(app_file).map_err(|e| {
             error!(
                 "❌ Failed to apply applications for branch: {}",
@@ -95,14 +90,11 @@ pub async fn get_resources(
                     match argocd.get_manifests(name) {
                         Ok(o) => {
                             write_to_file(&format!("{}/{}", destination_folder, name), &o.stdout)?;
-                            debug!("Got manifests for application: {}", name);
-                            processed_apps.insert(name.to_string().clone());
+                            debug!("Got manifests for application: {}", name)
                         }
-                        Err(e) => {
-                            error!("❌ Failed to get manifests for application: {}", name);
-                            failed_apps.insert(name.to_string().clone(), e.stderr);
-                        }
+                        Err(e) => error!("error: {}", e.stderr),
                     }
+                    processed_apps.insert(name.to_string().clone());
                     continue;
                 }
                 Some("Unknown") => {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,10 +1,5 @@
-use crate::{
-    argo_resource::{ApplicationKind, ArgoResource},
-    argocd::ArgoCDInstallation,
-    error::CommandError,
-    utils, Branch, Selector,
-};
-use log::{debug, error, info};
+use crate::{argo_resource::ArgoResource, Branch, Selector};
+use log::{debug, info};
 use regex::Regex;
 use serde_yaml::Value;
 use std::{error::Error, io::BufRead};
@@ -23,7 +18,7 @@ impl Clone for K8sResource {
     }
 }
 
-pub fn get_applications_for_branches(
+pub fn get_applications_for_branches<'a>(
     argo_cd_namespace: &str,
     base_branch: &Branch,
     target_branch: &Branch,
@@ -87,25 +82,25 @@ pub fn get_applications_for_branches(
             .collect();
 
         info!(
-            "🤖 Skipped {} Application[Sets] for branch: '{}' because they have not changed after patching",
+            "🤖 Skipped {} applications for branch: '{}' because they have not changed after patching",
             base_apps_before - base_apps.len(),
             base_branch.name
         );
 
         info!(
-            "🤖 Skipped {} Application[Sets] for branch: '{}' because they have not changed after patching",
+            "🤖 Skipped {} applications for branch: '{}' because they have not changed after patching",
             target_apps_before - target_apps.len(),
             target_branch.name
         );
 
         info!(
-            "🤖 Using the remaining {} Application[Sets] for branch: '{}'",
+            "🤖 Using the remaining {} applications for branch: '{}'",
             base_apps.len(),
             base_branch.name
         );
 
         info!(
-            "🤖 Using the remaining {} Application[Sets] for branch: '{}'",
+            "🤖 Using the remaining {} applications for branch: '{}'",
             target_apps.len(),
             target_branch.name
         );
@@ -132,14 +127,7 @@ fn get_applications(
         ignore_invalid_watch_pattern,
     );
     if !applications.is_empty() {
-        info!("🤖 Patching Application[Sets] for branch: {}", branch.name);
-        let apps = patch_applications(argo_cd_namespace, applications, branch, repo)?;
-        info!(
-            "🤖 Patching {} Argo CD Application[Sets] for branch: {}",
-            apps.len(),
-            branch.name
-        );
-        return Ok(apps);
+        return patch_applications(argo_cd_namespace, applications, branch, repo);
     }
     Ok(applications)
 }
@@ -226,38 +214,53 @@ fn parse_yaml(directory: &str, files: Vec<String>) -> Vec<K8sResource> {
         .collect()
 }
 
-fn patch_application(
-    argo_cd_namespace: &str,
-    application: ArgoResource,
-    branch: &Branch,
-    repo: &str,
-) -> Result<ArgoResource, Box<dyn Error>> {
-    let app_name = application.name.clone();
-    let app = application
-        .set_namespace(argo_cd_namespace)
-        .remove_sync_policy()
-        .set_project_to_default()
-        .and_then(|a| a.point_destination_to_in_cluster())
-        .and_then(|a| a.redirect_sources(repo, &branch.name))
-        .and_then(|a| a.redirect_generators(repo, &branch.name));
-
-    if app.is_err() {
-        error!("❌ Failed to patch application: {}", app_name);
-    }
-
-    app
-}
-
 fn patch_applications(
     argo_cd_namespace: &str,
     applications: Vec<ArgoResource>,
     branch: &Branch,
     repo: &str,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
-    applications
+    info!("🤖 Patching applications for branch: {}", branch.name);
+
+    let applications: Vec<Result<ArgoResource, Box<dyn Error>>> = applications
         .into_iter()
-        .map(|a| patch_application(argo_cd_namespace, a, branch, repo))
-        .collect()
+        .map(|a| {
+            let app_name = a.name.clone();
+            let app: Result<ArgoResource, Box<dyn Error>> = a
+                .set_namespace(argo_cd_namespace)
+                .remove_sync_policy()
+                .set_project_to_default()
+                .and_then(|a| a.point_destination_to_in_cluster())
+                .and_then(|a| a.redirect_sources(repo, &branch.name))
+                .and_then(|a| a.redirect_generators(repo, &branch.name));
+
+            if app.is_err() {
+                info!("❌ Failed to patch application: {}", app_name);
+            }
+            app
+        })
+        .collect();
+
+    info!(
+        "🤖 Patching {} Argo CD Application[Sets] for branch: {}",
+        applications.len(),
+        branch.name
+    );
+
+    let errors: Vec<String> = applications
+        .iter()
+        .filter_map(|a| match a {
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        })
+        .collect();
+
+    if !errors.is_empty() {
+        return Err(errors.join("\n").into());
+    }
+
+    let apps = applications.into_iter().filter_map(|a| a.ok()).collect();
+    Ok(apps)
 }
 
 fn from_resource_to_application(
@@ -303,114 +306,16 @@ fn from_resource_to_application(
 
     if number_of_apps_before_filtering != filtered_apps.len() {
         info!(
-            "🤖 Found {} Application[Sets] before filtering",
+            "🤖 Found {} applications before filtering",
             number_of_apps_before_filtering
         );
         info!(
-            "🤖 Found {} Application[Sets] after filtering",
+            "🤖 Found {} applications after filtering",
             filtered_apps.len()
         );
     } else {
-        info!("🤖 Found {} Application[Sets]", number_of_apps_before_filtering);
+        info!("🤖 Found {} applications", number_of_apps_before_filtering);
     }
 
     filtered_apps
-}
-
-pub fn generate_apps_from_app_set(
-    argocd: &ArgoCDInstallation,
-    app_sets: Vec<ArgoResource>,
-    branch: &Branch,
-    repo: &str,
-    temp_folder: &str,
-) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
-    let mut apps_new: Vec<ArgoResource> = vec![];
-
-    let mut app_set_counter = 0;
-    let mut generated_apps_counter = 0;
-
-    for app_set in app_sets {
-        if app_set.kind != ApplicationKind::ApplicationSet {
-            apps_new.push(app_set);
-            continue;
-        }
-
-        app_set_counter += 1;
-
-        // generate random name for ApplicationSet
-        let random_file_name = format!(
-            "{}/{}-{}.yaml",
-            temp_folder,
-            app_set.name,
-            rand::random::<u32>()
-        );
-        utils::write_to_file(&random_file_name, &app_set.as_string()?)?;
-
-        debug!(
-            "Generating applications from ApplicationSet in file: {}",
-            random_file_name
-        );
-
-        let apps_string = argocd
-            .appset_generate(&random_file_name)
-            .map_err(|e| {
-                error!(
-                    "❌ Failed to generate applications from ApplicationSet in file: {}",
-                    app_set.file_name
-                );
-                CommandError::new(e)
-            })?
-            .stdout;
-
-        let yaml = serde_yaml::from_str(&apps_string).unwrap_or(serde_yaml::Value::Null);
-
-        let apps = match yaml.as_sequence() {
-            None => continue,
-            Some(s) => {
-                let apps = s
-                    .iter()
-                    .filter_map(|a| {
-                        ArgoResource::from_k8s_resource(K8sResource {
-                            file_name: app_set.file_name.clone(),
-                            yaml: a.clone(),
-                        })
-                    })
-                    .collect::<Vec<ArgoResource>>();
-                patch_applications(&argocd.namespace, apps, branch, repo)
-            }
-        };
-
-        match apps {
-            Ok(apps) => {
-                debug!(
-                    "Generated {} Applications from ApplicationSet in file: {}",
-                    apps.len(),
-                    app_set.file_name
-                );
-                generated_apps_counter += apps.len();
-                apps_new.extend(apps);
-            }
-            Err(e) => {
-                error!(
-                    "❌ Failed to generate Applications from ApplicationSet in file: {}",
-                    app_set.file_name
-                );
-                return Err(e);
-            }
-        }
-    }
-
-    info!(
-        "🤖 Generated {} applications from {} ApplicationSets for branch: {}",
-        generated_apps_counter, app_set_counter, branch.name
-    );
-
-    debug_assert!(
-        apps_new
-            .iter()
-            .all(|a| a.kind == ApplicationKind::Application),
-        "All applications should be of kind Application"
-    );
-
-    Ok(apps_new)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,13 +22,6 @@ pub fn check_if_folder_exists(folder_name: &str) -> bool {
     PathBuf::from(folder_name).is_dir()
 }
 
-pub fn delete_folder(folder_name: &str) -> Result<(), Box<dyn Error>> {
-    if check_if_folder_exists(folder_name) {
-        fs::remove_dir_all(folder_name)?;
-    }
-    Ok(())
-}
-
 pub fn run_command(command: &str) -> Result<CommandOutput, CommandOutput> {
     let args = command.split_whitespace().collect::<Vec<&str>>();
     run_command_from_list(args, None, None)


### PR DESCRIPTION
This PR reverts the logic that renders Application with the `argocd appset generate` command and replaces it with a logic that waits for all ApplicationSets to be processed, if ApplicationSets exist.

Resolves #85