### PR TITLE
Feat | Add target revision redirect selector

### DIFF
--- a/src/argo_resource.rs
+++ b/src/argo_resource.rs
@@ -106,6 +106,7 @@ impl ArgoResource {
         mut self,
         repo: &str,
         branch: &str,
+        redirect_selector: &Option<Vec<String>>,
     ) -> Result<ArgoResource, Box<dyn Error>> {
         let spec = match self.kind {
             ApplicationKind::Application => self.yaml["spec"].as_mapping_mut(),
@@ -122,8 +123,17 @@ impl ArgoResource {
                 }
                 match spec["source"]["repoURL"].as_str() {
                     Some(url) if url.to_lowercase().contains(&repo.to_lowercase()) => {
-                        spec["source"]["targetRevision"] =
-                            serde_yaml::Value::String(branch.to_string());
+                        let redirect = match redirect_selector {
+                            Some(revisions) => revisions.iter().any(|revision| {
+                                Some(revision.as_str()) == spec["source"]["targetRevision"].as_str()
+                            }),
+                            None => true,
+                        };
+
+                        if redirect {
+                            spec["source"]["targetRevision"] =
+                                serde_yaml::Value::String(branch.to_string());
+                        }
                     }
                     _ => debug!(
                         "Found no 'repoURL' under spec.source in file: {}",
@@ -140,8 +150,17 @@ impl ArgoResource {
                         }
                         match source["repoURL"].as_str() {
                             Some(url) if url.to_lowercase().contains(&repo.to_lowercase()) => {
-                                source["targetRevision"] =
-                                    serde_yaml::Value::String(branch.to_string());
+                                let redirect = match redirect_selector {
+                                    Some(revisions) => revisions.iter().any(|revision| {
+                                        Some(revision.as_str()) == source["targetRevision"].as_str()
+                                    }),
+                                    None => true,
+                                };
+
+                                if redirect {
+                                    source["targetRevision"] =
+                                        serde_yaml::Value::String(branch.to_string());
+                                }
                             }
                             _ => debug!(
                                 "Found no 'repoURL' under spec.sources[] in file: {}",
@@ -164,6 +183,7 @@ impl ArgoResource {
         mut self,
         repo: &str,
         branch: &str,
+        redirect_selector: &Option<Vec<String>>,
     ) -> Result<ArgoResource, Box<dyn Error>> {
         if self.kind != ApplicationKind::ApplicationSet {
             return Ok(self);
@@ -174,7 +194,9 @@ impl ArgoResource {
         match spec {
             None => Err(format!("No 'spec' key found in ApplicationSet: {}", self.name).into()),
             Some(spec) => {
-                if spec.contains_key("generators") && redirect_git_generator(spec, repo, branch) {
+                if spec.contains_key("generators")
+                    && redirect_git_generator(spec, repo, branch, redirect_selector)
+                {
                     debug!(
                         "Patched git generators in ApplicationSet: {} in file: {}",
                         self.name, self.file_name
@@ -330,14 +352,19 @@ impl ArgoResource {
 }
 
 // Returns true if the generators were patched
-fn redirect_git_generator(v: &mut Mapping, repo: &str, branch: &str) -> bool {
+fn redirect_git_generator(
+    v: &mut Mapping,
+    repo: &str,
+    branch: &str,
+    redirect_selector: &Option<Vec<String>>,
+) -> bool {
     let mut patched = false;
     if v.contains_key("generators") {
         if let Some(i) = v["generators"].as_sequence_mut() {
             for generator in i {
                 if generator["matrix"].is_mapping() {
                     if let Some(i) = generator["matrix"].as_mapping_mut() {
-                        let redirected = redirect_git_generator(i, repo, branch);
+                        let redirected = redirect_git_generator(i, repo, branch, redirect_selector);
                         patched = redirected || patched;
                     }
                 }
@@ -346,9 +373,24 @@ fn redirect_git_generator(v: &mut Mapping, repo: &str, branch: &str) -> bool {
                         if git.contains_key("repoURL") {
                             match git["repoURL"].as_str() {
                                 Some(url) if url.to_lowercase().contains(&repo.to_lowercase()) => {
-                                    git["revision"] = serde_yaml::Value::String(branch.to_string());
-                                    debug!("Redirected 'repoURL' in git generator",);
-                                    patched = true;
+                                    let redirect = match redirect_selector {
+                                        Some(revisions) => revisions.iter().any(|revision| {
+                                            Some(revision.as_str()) == git["revision"].as_str()
+                                        }),
+                                        None => true,
+                                    };
+
+                                    if redirect {
+                                        git["revision"] =
+                                            serde_yaml::Value::String(branch.to_string());
+                                        debug!("Redirected 'repoURL' in git generator",);
+
+                                        patched = true;
+                                    } else {
+                                        debug!(
+                                            "Skipped unselected `targetRevision` in git generator"
+                                        )
+                                    }
                                 }
                                 Some(_url) => {
                                     debug!("Found no matching 'repoURL' in git generator")

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -32,6 +32,7 @@ pub fn get_applications_for_branches(
     files_changed: &Option<Vec<String>>,
     repo: &str,
     ignore_invalid_watch_pattern: bool,
+    redirect_selector: &Option<Vec<String>>,
 ) -> Result<(Vec<ArgoResource>, Vec<ArgoResource>), Box<dyn Error>> {
     let base_apps = get_applications(
         argo_cd_namespace,
@@ -41,6 +42,7 @@ pub fn get_applications_for_branches(
         files_changed,
         repo,
         ignore_invalid_watch_pattern,
+        redirect_selector,
     )?;
     let target_apps = get_applications(
         argo_cd_namespace,
@@ -50,6 +52,7 @@ pub fn get_applications_for_branches(
         files_changed,
         repo,
         ignore_invalid_watch_pattern,
+        redirect_selector,
     )?;
 
     let duplicate_yaml = base_apps
@@ -122,6 +125,7 @@ fn get_applications(
     files_changed: &Option<Vec<String>>,
     repo: &str,
     ignore_invalid_watch_pattern: bool,
+    redirect_selector: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     let yaml_files = get_yaml_files(branch.folder_name(), regex);
     let k8s_resources = parse_yaml(branch.folder_name(), yaml_files);
@@ -133,7 +137,13 @@ fn get_applications(
     );
     if !applications.is_empty() {
         info!("🤖 Patching Application[Sets] for branch: {}", branch.name);
-        let apps = patch_applications(argo_cd_namespace, applications, branch, repo)?;
+        let apps = patch_applications(
+            argo_cd_namespace,
+            applications,
+            branch,
+            repo,
+            redirect_selector,
+        )?;
         info!(
             "🤖 Patching {} Argo CD Application[Sets] for branch: {}",
             apps.len(),
@@ -231,6 +241,7 @@ fn patch_application(
     application: ArgoResource,
     branch: &Branch,
     repo: &str,
+    redirect_selector: &Option<Vec<String>>,
 ) -> Result<ArgoResource, Box<dyn Error>> {
     let app_name = application.name.clone();
     let app = application
@@ -238,8 +249,8 @@ fn patch_application(
         .remove_sync_policy()
         .set_project_to_default()
         .and_then(|a| a.point_destination_to_in_cluster())
-        .and_then(|a| a.redirect_sources(repo, &branch.name))
-        .and_then(|a| a.redirect_generators(repo, &branch.name));
+        .and_then(|a| a.redirect_sources(repo, &branch.name, redirect_selector))
+        .and_then(|a| a.redirect_generators(repo, &branch.name, redirect_selector));
 
     if app.is_err() {
         error!("❌ Failed to patch application: {}", app_name);
@@ -253,10 +264,11 @@ fn patch_applications(
     applications: Vec<ArgoResource>,
     branch: &Branch,
     repo: &str,
+    redirect_selector: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     applications
         .into_iter()
-        .map(|a| patch_application(argo_cd_namespace, a, branch, repo))
+        .map(|a| patch_application(argo_cd_namespace, a, branch, repo, redirect_selector))
         .collect()
 }
 
@@ -326,6 +338,7 @@ pub fn generate_apps_from_app_set(
     branch: &Branch,
     repo: &str,
     temp_folder: &str,
+    redirect_selector: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     let mut apps_new: Vec<ArgoResource> = vec![];
 
@@ -379,7 +392,7 @@ pub fn generate_apps_from_app_set(
                         })
                     })
                     .collect::<Vec<ArgoResource>>();
-                patch_applications(&argocd.namespace, apps, branch, repo)
+                patch_applications(&argocd.namespace, apps, branch, repo, redirect_selector)
             }
         };
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -32,7 +32,7 @@ pub fn get_applications_for_branches(
     files_changed: &Option<Vec<String>>,
     repo: &str,
     ignore_invalid_watch_pattern: bool,
-    redirect_selector: &Option<Vec<String>>,
+    redirect_target_revisions: &Option<Vec<String>>,
 ) -> Result<(Vec<ArgoResource>, Vec<ArgoResource>), Box<dyn Error>> {
     let base_apps = get_applications(
         argo_cd_namespace,
@@ -42,7 +42,7 @@ pub fn get_applications_for_branches(
         files_changed,
         repo,
         ignore_invalid_watch_pattern,
-        redirect_selector,
+        redirect_target_revisions,
     )?;
     let target_apps = get_applications(
         argo_cd_namespace,
@@ -52,7 +52,7 @@ pub fn get_applications_for_branches(
         files_changed,
         repo,
         ignore_invalid_watch_pattern,
-        redirect_selector,
+        redirect_target_revisions,
     )?;
 
     let duplicate_yaml = base_apps
@@ -125,7 +125,7 @@ fn get_applications(
     files_changed: &Option<Vec<String>>,
     repo: &str,
     ignore_invalid_watch_pattern: bool,
-    redirect_selector: &Option<Vec<String>>,
+    redirect_target_revisions: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     let yaml_files = get_yaml_files(branch.folder_name(), regex);
     let k8s_resources = parse_yaml(branch.folder_name(), yaml_files);
@@ -142,7 +142,7 @@ fn get_applications(
             applications,
             branch,
             repo,
-            redirect_selector,
+            redirect_target_revisions,
         )?;
         info!(
             "🤖 Patching {} Argo CD Application[Sets] for branch: {}",
@@ -241,7 +241,7 @@ fn patch_application(
     application: ArgoResource,
     branch: &Branch,
     repo: &str,
-    redirect_selector: &Option<Vec<String>>,
+    redirect_target_revisions: &Option<Vec<String>>,
 ) -> Result<ArgoResource, Box<dyn Error>> {
     let app_name = application.name.clone();
     let app = application
@@ -249,8 +249,8 @@ fn patch_application(
         .remove_sync_policy()
         .set_project_to_default()
         .and_then(|a| a.point_destination_to_in_cluster())
-        .and_then(|a| a.redirect_sources(repo, &branch.name, redirect_selector))
-        .and_then(|a| a.redirect_generators(repo, &branch.name, redirect_selector));
+        .and_then(|a| a.redirect_sources(repo, &branch.name, redirect_target_revisions))
+        .and_then(|a| a.redirect_generators(repo, &branch.name, redirect_target_revisions));
 
     if app.is_err() {
         error!("❌ Failed to patch application: {}", app_name);
@@ -264,11 +264,19 @@ fn patch_applications(
     applications: Vec<ArgoResource>,
     branch: &Branch,
     repo: &str,
-    redirect_selector: &Option<Vec<String>>,
+    redirect_target_revisions: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     applications
         .into_iter()
-        .map(|a| patch_application(argo_cd_namespace, a, branch, repo, redirect_selector))
+        .map(|a| {
+            patch_application(
+                argo_cd_namespace,
+                a,
+                branch,
+                repo,
+                redirect_target_revisions,
+            )
+        })
         .collect()
 }
 
@@ -338,7 +346,7 @@ pub fn generate_apps_from_app_set(
     branch: &Branch,
     repo: &str,
     temp_folder: &str,
-    redirect_selector: &Option<Vec<String>>,
+    redirect_target_revisions: &Option<Vec<String>>,
 ) -> Result<Vec<ArgoResource>, Box<dyn Error>> {
     let mut apps_new: Vec<ArgoResource> = vec![];
 
@@ -392,7 +400,13 @@ pub fn generate_apps_from_app_set(
                         })
                     })
                     .collect::<Vec<ArgoResource>>();
-                patch_applications(&argocd.namespace, apps, branch, repo, redirect_selector)
+                patch_applications(
+                    &argocd.namespace,
+                    apps,
+                    branch,
+                    repo,
+                    redirect_target_revisions,
+                )
             }
         };
 


### PR DESCRIPTION
* Provides a flag that allow the user to specify which target revision will be redirected to the target branch while generating the diff. It keeps unselected revision of application or applicationset as is.