### PR TITLE
Fixed crash due to missing project key in Application

### DIFF
--- a/src/argo_resource.rs
+++ b/src/argo_resource.rs
@@ -51,10 +51,15 @@ impl ArgoResource {
 
         match spec {
             None => Err(format!("No 'spec' key found in Application: {}", self.name).into()),
-            Some(spec) => {
+            Some(spec) if spec.contains_key("project") => {
                 spec["project"] = serde_yaml::Value::String("default".to_string());
                 Ok(self)
             }
+            Some(_) => Err(format!(
+                "No 'spec.project' key found in Application: {} (file: {})",
+                self.name, self.file_name
+            )
+            .into()),
         }
     }
 
@@ -76,8 +81,8 @@ impl ArgoResource {
                 Ok(self)
             }
             Some(_) => Err(format!(
-                "No 'spec.destination' key found in Application: {}",
-                self.name
+                "No 'spec.destination' key found in Application: {} (file: {})",
+                self.name, self.file_name
             )
             .into()),
         }


### PR DESCRIPTION
Related to this issue: https://github.com/dag-andersen/argocd-diff-preview/issues/101

This will provide a readable error if the user tries to render an Application that does not have a project specified.