### PR TITLE
Fixed applications removal stuck due to obstructive finalizers

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -5,7 +5,6 @@ use crate::{apply_manifest, Branch};
 use log::{debug, error, info};
 use serde_yaml::Value;
 use std::collections::HashSet;
-use std::env;
 use std::fs;
 use std::{collections::BTreeMap, error::Error};
 
@@ -230,7 +229,6 @@ static FINALIZERS: [&str; 2] = [
 ];
 
 pub fn remove_obstructive_finalizers() -> Result<(), Box<dyn Error>> {
-
     let command = "kubectl get applications -A -oyaml";
     let command_output = run_simple_command(command).map_err(|e| {
         error!("❌ Failed to get applications: {}", e.stderr);
@@ -246,7 +244,10 @@ pub fn remove_obstructive_finalizers() -> Result<(), Box<dyn Error>> {
     };
 
     for item in applications {
-        let (name, namespace) = match (item["metadata"]["name"].as_str(), item["metadata"]["namespace"].as_str()) {
+        let (name, namespace) = match (
+            item["metadata"]["name"].as_str(),
+            item["metadata"]["namespace"].as_str(),
+        ) {
             (Some(name), Some(namespace)) => (name, namespace),
             _ => continue,
         };
@@ -254,7 +255,8 @@ pub fn remove_obstructive_finalizers() -> Result<(), Box<dyn Error>> {
             .as_sequence()
             .and_then(|f| {
                 // check if any of the finalizers are in the list of finalizers to remove
-                f.iter().find(|f| FINALIZERS.contains(&f.as_str().unwrap_or_default()))
+                f.iter()
+                    .find(|f| FINALIZERS.contains(&f.as_str().unwrap_or_default()))
             })
             .is_some();
 


### PR DESCRIPTION
* The finalizers:
    - post-delete-finalizer.argocd.argoproj.io
    - post-delete-finalizer.argoproj.io/cleanup

  are added by ArgoCD when the rendered manifests include a post-delete hook. In this case, the application will not be deleted since we could not satisfy the finalizer condition. Therefore, removed the finalizers.

  See:
  [1] for PostDeleteFinalizerName reference
  [2] for implementation of these finalizers adding

---
[1] https://github.com/argoproj/argo-cd/blame/8a447d9ae01f0c4358bc0d7553c120c43a8b99e5/pkg/apis/application/v1alpha1/application_defaults.go#L12-L13
[2] https://github.com/argoproj/argo-cd/pull/16595