### PR TITLE
fix(test): drop an incorrect invalid repo validation test case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN curl -sSL -o argocd-linux-${TARGETARCH} https://github.com/argoproj/argo-cd/
 RUN install -m 555 argocd-linux-${TARGETARCH} /usr/local/bin/argocd
 RUN rm argocd-linux-${TARGETARCH}
 
+# run test
+RUN cargo test
+
 # build for release
 RUN rm ./target/release/deps/argocd_diff_preview-*
 RUN cargo build --release

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -163,7 +163,6 @@ mod tests {
             "owner",
             "owner/",
             "/repo",
-            "owner/repo/extra",
             "owner repo",
             "owner@repo",
             "owner#repo",


### PR DESCRIPTION
* Refers to [1], an incorrect invalid repo validation test case was added, and causes the test failed. Therefore, dropped it.

  ---
  [1] https://github.com/dag-andersen/argocd-diff-preview/commit/38171b3f31c3812dc141c326fdef9a6befa3ac66