### PR TITLE
[Docs] Adjust URL for Private SSH Keys

### DIFF
--- a/docs/github-actions-workflow.md
+++ b/docs/github-actions-workflow.md
@@ -107,7 +107,7 @@ If your ArgoCD Applications use SSH to access the private repositories, then you
             argocd.argoproj.io/secret-type: repo-creds
         stringData:
           type: git
-          url: https://github.com/${{ github.repository }}
+          url: git@github.com/${{ github.repository }}
           sshPrivateKey: |
         $(echo "${{ secrets.REPO_ACCESS_SSH_PRIVATE_KEY }}" | sed 's/^/    /') ⬅️ Private SSH key with proper indentation
         EOF


### PR DESCRIPTION
I ran into a problem with the existing example during setup and wanted to update the documentation.

In the event you need to use an SSH private key for configuring your applications, you'll likely want this URL in an SSH format (not HTTPS). I hit this bug during my setup and was able to resolve it using the fix below. Hopefully it helps others!