### PR TITLE
Add a new option for kind-options

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -36,6 +36,7 @@ var (
 	DefaultSecretsFolder      = "./secrets"
 	DefaultCluster            = "auto"
 	DefaultClusterName        = "argocd-diff-preview"
+	DefaultKindOptions        = ""
 	DefaultMaxDiffLength      = uint(65536)
 	DefaultArgocdNamespace    = "argocd"
 	DefaultLogFormat          = "human"
@@ -56,6 +57,7 @@ type Options struct {
 	SecretsFolder             string `mapstructure:"secrets-folder"`
 	ClusterType               string `mapstructure:"cluster"`
 	ClusterName               string `mapstructure:"cluster-name"`
+	KindOptions               string `mapstructure:"kind-options"`
 	MaxDiffLength             uint   `mapstructure:"max-diff-length"`
 	Selector                  string `mapstructure:"selector"`
 	FilesChanged              string `mapstructure:"files-changed"`
@@ -212,6 +214,7 @@ func Parse() *Options {
 	// Cluster related
 	rootCmd.Flags().String("cluster", DefaultCluster, "Local cluster tool. Options: kind, minikube, auto")
 	rootCmd.Flags().String("cluster-name", DefaultClusterName, "Cluster name (only for kind)")
+	rootCmd.Flags().String("kind-options", DefaultKindOptions, "Kind Options (only for kind)")
 	rootCmd.Flags().Bool("keep-cluster-alive", false, "Keep cluster alive after the tool finishes")
 
 	// Other options
@@ -303,12 +306,12 @@ func (o *Options) ParseClusterType() (cluster.Provider, error) {
 	var provider cluster.Provider
 	switch o.ClusterType {
 	case "kind":
-		provider = kind.New(o.ClusterName)
+		provider = kind.New(o.ClusterName, o.KindOptions)
 	case "minikube":
 		provider = minikube.New()
 	case "auto":
 		if kind.IsInstalled() {
-			provider = kind.New(o.ClusterName)
+			provider = kind.New(o.ClusterName, o.KindOptions)
 			log.Debug().Msg("Using kind as cluster provider")
 		} else if minikube.IsInstalled() {
 			provider = minikube.New()
@@ -336,6 +339,7 @@ func (o *Options) LogOptions() {
 	}
 	log.Info().Msgf("✨ - local-cluster-tool: %s", o.clusterProvider.GetName())
 	log.Info().Msgf("✨ - cluster-name: %s", o.ClusterName)
+	log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
 	log.Info().Msgf("✨ - base-branch: %s", o.BaseBranch)
 	log.Info().Msgf("✨ - target-branch: %s", o.TargetBranch)
 	log.Info().Msgf("✨ - secrets-folder: %s", o.SecretsFolder)

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -339,7 +339,9 @@ func (o *Options) LogOptions() {
 	}
 	log.Info().Msgf("✨ - local-cluster-tool: %s", o.clusterProvider.GetName())
 	log.Info().Msgf("✨ - cluster-name: %s", o.ClusterName)
-	log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
+	if o.KindOptions != "" {
+		log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
+	}
 	log.Info().Msgf("✨ - base-branch: %s", o.BaseBranch)
 	log.Info().Msgf("✨ - target-branch: %s", o.TargetBranch)
 	log.Info().Msgf("✨ - secrets-folder: %s", o.SecretsFolder)

--- a/docs/options.md
+++ b/docs/options.md
@@ -34,6 +34,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--base-branch <branch>`, `-b` | `BASE_BRANCH` | `main` | Base branch name |
 | `--cluster <tool>` | `CLUSTER` | `auto` | Local cluster tool. Options: kind, minikube, auto |
 | `--cluster-name <name>` | `CLUSTER_NAME` | `argocd-diff-preview` | Cluster name (only for kind) |
+| `--kind-options <options>` | `KIND_OPTIONS` | - | Additional options for kind cluster creation |
 | `--diff-ignore <pattern>`, `-i` | `DIFF_IGNORE` | - | Ignore lines in diff. Example: `v[1,9]+.[1,9]+.[1,9]+` for ignoring version changes |
 | `--file-regex <regex>`, `-r` | `FILE_REGEX` | - | Regex to filter files. Example: `/apps_.*\.yaml` |
 | `--files-changed <files>` | `FILES_CHANGED` | - | List of files changed between branches (comma, space or newline separated) |

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -20,8 +20,8 @@ func IsInstalled() bool {
 	return err == nil
 }
 
-// CreateCluster creates a new kind cluster with the given name
-func CreateCluster(clusterName string) error {
+// CreateCluster creates a new kind cluster with the given name, optional kindOptions
+func CreateCluster(clusterName string, kindOptions string) error {
 	// Check if docker is running
 	if _, err := runCommand("docker", "ps"); err != nil {
 		log.Error().Msg("❌ Docker is not running")
@@ -36,7 +36,7 @@ func CreateCluster(clusterName string) error {
 	}
 
 	// Create new cluster
-	if _, err := runCommand("kind", "create", "cluster", "--name", clusterName); err != nil {
+	if _, err := runCommand("kind", "create", "cluster", "--name", clusterName, kindOptions); err != nil {
 		log.Error().Msg("❌ Failed to create cluster")
 		return fmt.Errorf("failed to create cluster: %w", err)
 	}
@@ -93,10 +93,11 @@ var _ cluster.Provider = (*Kind)(nil)
 
 type Kind struct {
 	clusterName string
+	kindOptions string
 }
 
-func New(clusterName string) *Kind {
-	return &Kind{clusterName: clusterName}
+func New(clusterName string, kindOptions string) *Kind {
+	return &Kind{clusterName: clusterName, kindOptions: kindOptions}
 }
 
 // Implement cluster.Provider interface
@@ -105,7 +106,7 @@ func (k *Kind) IsInstalled() bool {
 }
 
 func (k *Kind) CreateCluster() error {
-	return CreateCluster(k.clusterName)
+	return CreateCluster(k.clusterName, k.kindOptions)
 }
 
 func (k *Kind) ClusterExists() bool {


### PR DESCRIPTION
Some of the options that can be passed include --image / --config etc.

One of the benefits is that we can use --config to pass our own cluster config for kind and override any settings as needed including image ver / location for kindest node. Tested by running this locally in my env and seems to work but would require somebody more versed with go to double check.

tested by passing -e KIND_OPTIONS to the image with my --config= override