### PR TITLE
Fix | handle argocd-repo-server slow start

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -221,6 +221,10 @@ func (a *ArgoCDInstallation) installWithHelm() error {
 		return fmt.Errorf("failed to wait for argocd-server to be ready: %w", err)
 	}
 
+	if err := a.K8sClient.WaitForDeploymentReady(a.Namespace, "argocd-repo-server", int(timeout.Seconds())); err != nil {
+		return fmt.Errorf("failed to wait for argocd-repo-server to be ready: %w", err)
+	}
+
 	// Log installed versions
 	log.Info().Msgf("🦑 Installed Chart version: '%s' and App version: '%s'",
 		chart.Metadata.Version, chart.Metadata.AppVersion)


### PR DESCRIPTION
* The argocd-repo-server service is required by the application and applicationset manifests generation, sometimes, a slow start of this service causes an intermittent failure with following error,

  ```bash
   ❌ argocd appset generate failed: ... desc = \"transport: Error while dialing: dial tcp 10.96.216.13:8081: connect: connection refused\"": exit status 20
   ```

  Therefore, we need to ensure that the service is ready before starting the manifests generation.