### PR TITLE
Fix | Skip appending to changedFiles if diffContent is empty

### DIFF
--- a/pkg/diff/generator.go
+++ b/pkg/diff/generator.go
@@ -359,6 +359,10 @@ func generateGitDiff(
 			diffContent = formatModifiedFileDiff(oldContent, newContent, diffContextLines, diffIgnore)
 		}
 
+		if diffContent == "" {
+			continue
+		}
+
 		toName := ""
 		fromName := ""
 		if to != nil {


### PR DESCRIPTION
This prevents empty entries from being created in diff.md when all differences in the target file are ignored by `--diff-ignore`.
