### PR TITLE
Feat | Support internal Kind clusters

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -360,7 +360,9 @@ func (o *Options) LogOptions() {
 		if o.KindOptions != "" {
 			log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
 		}
-		log.Info().Msgf("✨ - kind-internal: %t", o.KindInternal)
+		if o.KindInternal {
+			log.Info().Msgf("✨ - kind-internal: %t", o.KindInternal)
+		}
 	}
 	if o.clusterProvider.GetName() == "k3d" && o.K3dOptions != "" {
 		log.Info().Msgf("✨ - k3d-options: %s", o.K3dOptions)

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -61,6 +61,7 @@ type Options struct {
 	ClusterType               string `mapstructure:"cluster"`
 	ClusterName               string `mapstructure:"cluster-name"`
 	KindOptions               string `mapstructure:"kind-options"`
+	KindInternal              bool   `mapstructure:"kind-internal"`
 	K3dOptions                string `mapstructure:"k3d-options"`
 	MaxDiffLength             uint   `mapstructure:"max-diff-length"`
 	Selector                  string `mapstructure:"selector"`
@@ -221,6 +222,7 @@ func Parse() *Options {
 	rootCmd.Flags().String("cluster", DefaultCluster, "Local cluster tool. Options: kind, minikube, k3d, auto")
 	rootCmd.Flags().String("cluster-name", DefaultClusterName, "Cluster name (only for kind & k3d)")
 	rootCmd.Flags().String("kind-options", DefaultKindOptions, "kind options (only for kind)")
+	rootCmd.Flags().Bool("kind-internal", false, "kind internal kubeconfig mode (only for kind)")
 	rootCmd.Flags().String("k3d-options", DefaultK3dOptions, "k3d options (only for k3d)")
 	rootCmd.Flags().Bool("keep-cluster-alive", false, "Keep cluster alive after the tool finishes")
 
@@ -316,14 +318,14 @@ func (o *Options) ParseClusterType() (cluster.Provider, error) {
 
 	switch clusterType {
 	case "kind":
-		provider = kind.New(o.ClusterName, o.KindOptions)
+		provider = kind.New(o.ClusterName, o.KindOptions, o.KindInternal)
 	case "k3d":
 		provider = k3d.New(o.ClusterName, o.K3dOptions)
 	case "minikube":
 		provider = minikube.New()
 	case "auto":
 		if kind.IsInstalled() {
-			provider = kind.New(o.ClusterName, o.KindOptions)
+			provider = kind.New(o.ClusterName, o.KindOptions, o.KindInternal)
 			log.Debug().Msg("Using kind as cluster provider (auto-detected)")
 		} else if k3d.IsInstalled() {
 			provider = k3d.New(o.ClusterName, o.K3dOptions)

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -356,8 +356,11 @@ func (o *Options) LogOptions() {
 	}
 	log.Info().Msgf("✨ - local-cluster-tool: %s", o.clusterProvider.GetName())
 	log.Info().Msgf("✨ - cluster-name: %s", o.ClusterName)
-	if o.clusterProvider.GetName() == "kind" && o.KindOptions != "" {
-		log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
+	if o.clusterProvider.GetName() == "kind" {
+		if o.KindOptions != "" {
+			log.Info().Msgf("✨ - kind-options: %s", o.KindOptions)
+		}
+		log.Info().Msgf("✨ - kind-internal: %t", o.KindInternal)
 	}
 	if o.clusterProvider.GetName() == "k3d" && o.K3dOptions != "" {
 		log.Info().Msgf("✨ - k3d-options: %s", o.K3dOptions)

--- a/docs/options.md
+++ b/docs/options.md
@@ -35,6 +35,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--cluster <tool>` | `CLUSTER` | `auto` | Local cluster tool. Options: kind, minikube, auto |
 | `--cluster-name <name>` | `CLUSTER_NAME` | `argocd-diff-preview` | Cluster name (only for kind) |
 | `--kind-options <options>` | `KIND_OPTIONS` | - | Additional options for kind cluster creation |
+| `--kind-internal` | `KIND_INTERNAL` | `false` | Use the kind cluster's internal address in the kubeconfig. Allows connecting to it when running the CLI in a container. |
 | `--diff-ignore <pattern>`, `-i` | `DIFF_IGNORE` | - | Ignore lines in diff. Example: `v[1,9]+.[1,9]+.[1,9]+` for ignoring version changes |
 | `--file-regex <regex>`, `-r` | `FILE_REGEX` | - | Regex to filter files. Example: `/apps_.*\.yaml` |
 | `--files-changed <files>` | `FILES_CHANGED` | - | List of files changed between branches (comma, space or newline separated) |

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -56,9 +56,8 @@ func CreateCluster(clusterName string, kindOptions string, internal bool) error 
 	if internal {
 		log.Debug().Msg("Manually writing internal kubeconfig because --kind-internal flag is set")
 
-		var output string
-		var err error
-		if output, err = runCommand("kind", "get", "kubeconfig", "--internal", "--name", clusterName); err != nil {
+		output, err := runCommand("kind", "get", "kubeconfig", "--internal", "--name", clusterName)
+		if err != nil {
 			return fmt.Errorf("failed to get cluster kubeconfig: %s", output)
 		}
 

--- a/pkg/utils/k8s-client.go
+++ b/pkg/utils/k8s-client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/yaml"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,11 +34,7 @@ type K8sClient struct {
 }
 
 func NewK8sClient() (*K8sClient, error) {
-
-	var kubeconfig string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = filepath.Join(home, ".kube", "config")
-	}
+	kubeconfig := GetKubeConfigPath()
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"k8s.io/client-go/util/homedir"
+	"path/filepath"
+)
+
+func GetKubeConfigPath() string {
+	if home := homedir.HomeDir(); home != "" {
+		return filepath.Join(home, ".kube", "config")
+	}
+	return ""
+}


### PR DESCRIPTION
## Context
When trying to use `argocd-diff-preview` with Forgejo/Gitea Actions, the binary needs to be used as mounting volumes from a workdir is not supported. Due to this, the `--network=host` is not available as that would require adding action containers to that network on a runner level. As such, the CLI will run in a container next to the created kind cluster.
 
## The Problem
Unfortunately, the `kind create cluster` command [always](https://github.com/kubernetes-sigs/kind/blob/ce37e37458a4c235a93920b3ce70f399aff19fd7/pkg/cluster/internal/create/create.go#L154) automatically generates a Kubeconfig file using `127.0.0.1` + the randomly assigned port as the address. I'd assume that this is the reason for using `--network=host` in the Docker-based samples in the first place.

## The Fix
Thankfully, the explicit `kind get kubeconfig` command [has a `--internal` flag that solves this issue](https://github.com/kubernetes-sigs/kind/issues/2148#issuecomment-803681341).
Therefore, I added a `--kind-internal` flag. It manually writes the kubeconfig file again, only this time with `https://{clustername}-control-plane:6443` as the cluster server.

## Closing Thoughts
I chose to only write the kubeconfig file manually if the new flag is enabled. If it isn't, `kind create cluster` will write it implicitly. It may be worth only making the `--internal` flag of the `get kubeconfig` subcommand optional and writing the file manually in any case to improve consistency and avoid drift between the two code paths.
Of course, I'm open to general criticism regarding this PR.

Massive thank you for the maintenance efforts, I'm absolutely impressed by the pace this project is evolving at! After running it on GitHub for a few months, it has proven to provide enough value to even warrant spending hours trying to integrate it with Forgejo.