### PR TITLE
Update GHA readme: Use merge commit on target branch for accurate diff

### DIFF
--- a/docs/github-actions-workflow.md
+++ b/docs/github-actions-workflow.md
@@ -37,7 +37,7 @@ jobs:
             -v $(pwd)/main:/base-branch \
             -v $(pwd)/pull-request:/target-branch \
             -v $(pwd)/output:/output \
-            -e TARGET_BRANCH=${{ github.head_ref }} \
+            -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
             -e REPO=${{ github.repository }} \
             dagandersen/argocd-diff-preview:v0.1.8
 


### PR DESCRIPTION
Hi,

Amazing tool, thank you! I'm testing it currently and I noticed your tool is showing changes that do not include the latest version of main.

For example, in the following image, the image change has been updated from `016f97e` to `47c0da5` upstream, so the diff shows this image being reverted as part of the diff:

<img width="498" alt="image" src="https://github.com/user-attachments/assets/f4538033-74f2-4996-9187-cdfa9932afef" />

I find this a bit noisy and suspect it will confuse users.

```
      - uses: actions/checkout@v4
        with:
          path: pull-request
``` 

This correctly pulls the merge commit, but `${{ github.head_ref }}` passed to `TARGET_BRANCH` does not contain the upstream changes. Pointing this at the merge commit fixes the diff.

