### PR TITLE
Run readiness probes frequently for all components

### DIFF
--- a/argocd-config/values-override.yaml
+++ b/argocd-config/values-override.yaml
@@ -7,3 +7,41 @@ dex:
 configs:
   params:
     reposerver.git.request.timeout: "150s"
+# Readiness probe settings have been adjusted to start checks immediately (initialDelaySeconds: 0)
+# The failureThreshold is increased to ensure the total time before a pod is marked unhealthy remains similar to the default
+# This default duration is calculated using the original values from values.yaml for (initialDelaySeconds + failureThreshold * periodSeconds)
+controller:
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 1
+    failureThreshold: 40
+redis:
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 1
+    failureThreshold: 105
+server:
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 1
+    failureThreshold: 40
+repoServer:
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 1
+    failureThreshold: 40
+applicationSet:
+  readinessProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 1
+    successThreshold: 1
+    timeoutSeconds: 1
+    failureThreshold: 40


### PR DESCRIPTION
Related: https://github.com/dag-andersen/argocd-diff-preview/issues/176

This PR introduces frequent readiness probes, which run from the moment the pod is created as frequently as possible (every second). The total time the pod has to become ready is the same, as I greatly increased the `failureThreshold`.

Even though the number of probes we now run is few times larger than previously, the process itself is lightweight and is not expected to introduce any issues.

While testing these changes via the `run-integration-tests-docker` in the `Makefile`, I found the change to speedup the ArgoCD readiness by 10s (as can be seen with the "Argo CD installed successfully in Xs" log).

While running these integration tests locally I found that previously it took between 42 and 46 seconds, with a dominant being 45 seconds, whereas the new setup takes between 32 and 38 seconds, with a dominant being 35s, which gives us a nice save time of ~10s.