### PR TITLE
Add info on how to access helm charts in OCI-based registry

### DIFF
--- a/docs/github-actions-workflow.md
+++ b/docs/github-actions-workflow.md
@@ -113,30 +113,6 @@ If your ArgoCD Applications use SSH to access the private repositories, then you
         EOF
 ```
 
-If Helm Charts are stored as OCI images in a Docker registry (such as AWS ECR), additional fields must be added to the `stringData` section as shown below.
-```yaml title=".github/workflows/generate-diff.yml" linenums="24"
-    - name: Prepare secrets
-      run: |
-        mkdir secrets
-        cat > secrets/secret.yaml << "EOF"
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: private-registry
-          namespace: argocd
-          labels:
-            argocd.argoproj.io/secret-type: repository
-        stringData:
-          name: privateRegistry
-          url: ${{ secrets.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-          type: helm
-          enableOCI: "true"
-          forceHttpBasicAuth: "true"
-        EOF
-```
-
 If you get this type of error:
 
 ```txt
@@ -169,6 +145,30 @@ so you need to use the following alternative:
         data:
           url: "${URL_B64}"
           sshPrivateKey: "${SSH_PRIVATE_KEY_B64}"
+        EOF
+```
+
+If Helm Charts are stored as OCI images in a Docker registry (such as AWS ECR), additional fields must be added to the `stringData` section as shown below.
+```yaml title=".github/workflows/generate-diff.yml" linenums="24"
+    - name: Prepare secrets
+      run: |
+        mkdir secrets
+        cat > secrets/secret.yaml << "EOF"
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: private-registry
+          namespace: argocd
+          labels:
+            argocd.argoproj.io/secret-type: repository
+        stringData:
+          name: privateRegistry
+          url: ${{ secrets.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          type: helm
+          enableOCI: "true"
+          forceHttpBasicAuth: "true"
         EOF
 ```
 


### PR DESCRIPTION
A small update to the documentation which shows how to access Helm Charts in a OCI-based private registry, like AWS ECR. Maybe someone's going to find it useful.