### PR TITLE
Fix | Lookup readiness of Argo CD deployments based on labels

### DIFF
--- a/pkg/utils/k8s-client.go
+++ b/pkg/utils/k8s-client.go
@@ -391,9 +391,9 @@ func (c *K8sClient) GetSecretValue(namespace string, name string, key string) (s
 }
 
 // WaitForDeploymentReady waits for a deployment to be available
-// Equivalent to: kubectl wait --for=condition=available deployment/name
+// Looks for deployments with label app.kubernetes.io/name={name}
 func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSeconds int) error {
-	log.Debug().Msgf("Waiting for deployment %s in namespace %s to be ready", name, namespace)
+	log.Debug().Msgf("Waiting for deployment with label app.kubernetes.io/name=%s in namespace %s to be ready", name, namespace)
 
 	// Define the Deployment resource
 	deploymentRes := schema.GroupVersionResource{
@@ -406,28 +406,44 @@ func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSecond
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
+	// Create label selector
+	labelSelector := fmt.Sprintf("app.kubernetes.io/name=%s", name)
+
 	// Poll until ready or timeout
 	pollInterval := 1 * time.Second
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for deployment %s to be ready", name)
+			return fmt.Errorf("timeout waiting for deployment with label app.kubernetes.io/name=%s to be ready", name)
 		default:
-			// Get the current deployment state
-			deployment, err := c.clientset.Resource(deploymentRes).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			// List deployments with the label selector
+			deploymentList, err := c.clientset.Resource(deploymentRes).Namespace(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
 			if err != nil {
 				if strings.Contains(err.Error(), "not found") {
 					log.Debug().Msgf("Deployment %s not found, waiting...", name)
 					time.Sleep(pollInterval)
 					continue
 				}
-				return fmt.Errorf("failed to get deployment %s: %w", name, err)
+				return fmt.Errorf("failed to list deployments with label %s: %w", labelSelector, err)
 			}
+
+			// Check if any deployments were found
+			if len(deploymentList.Items) == 0 {
+				log.Debug().Msgf("No deployments found with label %s, waiting...", labelSelector)
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			// Use the first deployment found (there should typically be only one)
+			deployment := &deploymentList.Items[0]
+			deploymentName := deployment.GetName()
 
 			// Check if status field exists
 			_, found, err := unstructured.NestedMap(deployment.Object, "status")
 			if err != nil || !found {
-				log.Debug().Msgf("Status field not found in deployment %s, waiting...", name)
+				log.Debug().Msgf("Status field not found in deployment %s, waiting...", deploymentName)
 				time.Sleep(pollInterval)
 				continue
 			}
@@ -435,7 +451,7 @@ func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSecond
 			// Check if deployment is available
 			readyReplicas, found, err := unstructured.NestedInt64(deployment.Object, "status", "readyReplicas")
 			if err != nil || !found {
-				log.Debug().Msgf("readyReplicas field not found in deployment %s status, waiting...", name)
+				log.Debug().Msgf("readyReplicas field not found in deployment %s status, waiting...", deploymentName)
 				time.Sleep(pollInterval)
 				continue
 			}
@@ -443,32 +459,32 @@ func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSecond
 			desiredReplicas, found, err := unstructured.NestedInt64(deployment.Object, "spec", "replicas")
 			if err != nil || !found {
 				desiredReplicas = 1 // Default to 1 if not specified
-				log.Debug().Msgf("replicas field not found in deployment %s spec, assuming default of 1", name)
+				log.Debug().Msgf("replicas field not found in deployment %s spec, assuming default of 1", deploymentName)
 			}
 
 			// Get available replicas
 			availableReplicas, found, err := unstructured.NestedInt64(deployment.Object, "status", "availableReplicas")
 			if err != nil || !found {
 				availableReplicas = 0
-				log.Debug().Msgf("availableReplicas field not found in deployment %s status, assuming 0", name)
+				log.Debug().Msgf("availableReplicas field not found in deployment %s status, assuming 0", deploymentName)
 			}
 
 			// Get updated replicas
 			updatedReplicas, found, err := unstructured.NestedInt64(deployment.Object, "status", "updatedReplicas")
 			if err != nil || !found {
 				updatedReplicas = 0
-				log.Debug().Msgf("updatedReplicas field not found in deployment %s status, assuming 0", name)
+				log.Debug().Msgf("updatedReplicas field not found in deployment %s status, assuming 0", deploymentName)
 			}
 
 			// Log current status
 			log.Debug().Msgf("Deployment %s status: %d/%d replicas ready, %d available, %d updated",
-				name, readyReplicas, desiredReplicas, availableReplicas, updatedReplicas)
+				deploymentName, readyReplicas, desiredReplicas, availableReplicas, updatedReplicas)
 
 			// Check if deployment is ready
 			if readyReplicas == desiredReplicas && availableReplicas == desiredReplicas {
 				conditions, found, err := unstructured.NestedSlice(deployment.Object, "status", "conditions")
 				if err != nil || !found {
-					log.Debug().Msgf("No conditions found in deployment %s status, continuing to wait...", name)
+					log.Debug().Msgf("No conditions found in deployment %s status, continuing to wait...", deploymentName)
 					time.Sleep(pollInterval)
 					continue
 				}
@@ -496,7 +512,7 @@ func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSecond
 				}
 
 				if isAvailable {
-					log.Debug().Msgf("Deployment %s is ready and available", name)
+					log.Debug().Msgf("Deployment %s is ready and available", deploymentName)
 					return nil
 				}
 			}


### PR DESCRIPTION
This avoids issues related to deployment names being suffixed with the helm chart name