### PR TITLE
Chore | enhance the appearance of HTML diff

### DIFF
--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -23,10 +23,13 @@ body {
 .diff_container {
 	width: 910px;
 	overflow-x: scroll;
+	border-radius: 8px;
+	background:rgb(239, 239, 239);
+	scrollbar-width: none;
+	margin: 10px 0 10px 0;
 }
 table {
 	font-family: monospace;
-	border: solid 1px rgb(53, 44, 47);
 	border-spacing: 0px;
 	width: 100%;
 }
@@ -44,7 +47,8 @@ tr.comment_line {
 }
 pre {
 	margin: 0;
-	padding: 0;
+	padding-left: 15px;
+	padding-right: 15px;
 }
 </style>
 </head>
@@ -97,7 +101,7 @@ func printHTMLSection(header string, commentHeader string, content string) strin
 			rows += fmt.Sprintf(htmlLine, "normal_line", html.EscapeString(line))
 			continue
 		}
-		switch (line[0]) {
+		switch line[0] {
 		case '@':
 			rows += fmt.Sprintf(htmlLine, "comment_line", html.EscapeString(line))
 		case '-':
@@ -106,7 +110,7 @@ func printHTMLSection(header string, commentHeader string, content string) strin
 			rows += fmt.Sprintf(htmlLine, "added_line", html.EscapeString(line))
 		default:
 			rows += fmt.Sprintf(htmlLine, "normal_line", html.EscapeString(line))
-		}	
+		}
 	}
 	s = strings.ReplaceAll(s, "%rows%", rows)
 


### PR DESCRIPTION
[diff/html]
* Enhance the appearance of the diff container by adding background color, rounded corners, and margin.
* Adjust pre tag padding for better readability.

[cosmetic]
* Apply `go fmt` to adjust a minor Go style in switch statements.

<img width="985" alt="Screenshot 2568-06-14 at 17 54 29" src="https://github.com/user-attachments/assets/1bf65478-1396-4559-b2b7-9d4fd4790b2c" />
