### PR TITLE
Add info about dry-run to docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -20,6 +20,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | Flag | Environment Variable | Default | Description |
 |------|---------------------|---------|-------------|
 | `--debug`, `-d` | `DEBUG` | `false` | Activate debug mode |
+| `--dry-run`, `-n` | `DRY_RUN` | `false` | Perform a trial run listing the applications that would be processed |
 | `--ignore-invalid-watch-pattern` | `IGNORE_INVALID_WATCH_PATTERN` | `false` | Ignore invalid watch pattern Regex on Applications |
 | `--keep-cluster-alive` | `KEEP_CLUSTER_ALIVE` | `false` | Keep cluster alive after the tool finishes |
 | `--help`, `-h` | - | - | Prints help information |

--- a/docs/options.md
+++ b/docs/options.md
@@ -20,7 +20,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | Flag | Environment Variable | Default | Description |
 |------|---------------------|---------|-------------|
 | `--debug`, `-d` | `DEBUG` | `false` | Activate debug mode |
-| `--dry-run`, `-n` | `DRY_RUN` | `false` | Perform a trial run listing the applications that would be processed |
+| `--dry-run` | `DRY_RUN` | `false` | Perform a trial run listing the applications that would be processed |
 | `--ignore-invalid-watch-pattern` | `IGNORE_INVALID_WATCH_PATTERN` | `false` | Ignore invalid watch pattern Regex on Applications |
 | `--keep-cluster-alive` | `KEEP_CLUSTER_ALIVE` | `false` | Keep cluster alive after the tool finishes |
 | `--help`, `-h` | - | - | Prints help information |


### PR DESCRIPTION
reverts [`1224674` (#220)](https://github.com/dag-andersen/argocd-diff-preview/pull/220/commits/1224674a6a3d1d9d3d57b6e5fa13589aa029b4b7)