### PR TITLE
Feat | Print "⏰ Run time stats: [Applications: 2], [Full Run: 6s], ..."

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -357,6 +357,8 @@ func run(opts *Options) error {
 		return err
 	}
 
+	log.Info().Msgf("⏰ Run time stats: %s", infoBox.Stats())
+
 	return nil
 }
 

--- a/pkg/diff/infobox.go
+++ b/pkg/diff/infobox.go
@@ -14,6 +14,10 @@ type InfoBox struct {
 }
 
 func (t InfoBox) String() string {
-	return fmt.Sprintf("_Stats_:\n[Applications: %d], [Full Run: %s], [Rendering: %s], [Cluster: %s], [Argo CD: %s]",
+	return fmt.Sprintf("_Stats_:\n%s", t.Stats())
+}
+
+func (t InfoBox) Stats() string {
+	return fmt.Sprintf("[Applications: %d], [Full Run: %s], [Rendering: %s], [Cluster: %s], [Argo CD: %s]",
 		t.ApplicationCount, t.FullDuration.Round(time.Second), t.ExtractDuration.Round(time.Second), t.ClusterCreationDuration.Round(time.Second), t.ArgoCDInstallationDuration.Round(time.Second))
 }


### PR DESCRIPTION
So the output looks something like this:

```
✨ Running with:
✨ - reusing existing cluster
✨ - base-branch: integration-test/branch-10/base
✨ - target-branch: integration-test/branch-10/target
✨ - secrets-folder: ./secrets
✨ - output-folder: ./output
✨ - argocd-namespace: argocd
✨ - repo: dag-andersen/argocd-diff-preview
✨ - timeout: 90 seconds
✨ - keep-cluster-alive: true
✨ - line-count: 10
✨ - files-changed: examples/ignore-differences/app.yaml
🔑 Unique ID for this run: 72d1c
🤖 Fetching all files for branch (branch: integration-test/branch-10/base)
🤖 Found 53 files in dir base-branch (branch: integration-test/branch-10/base)
🤖 Which resulted in 33 k8sResources (branch: integration-test/branch-10/base)
🤖 Filtering 18 Application[Sets] (branch: integration-test/branch-10/base)
🤖 Will only run on Applications that watch these files: 'examples/ignore-differences/app.yaml'
🤖 Found 18 Application[Sets] before filtering (branch: integration-test/branch-10/base)
🤖 Found 1 Application[Sets] after filtering (branch: integration-test/branch-10/base)
🤖 Patching 1 Application[Sets] (branch: integration-test/branch-10/base)
🤖 Fetching all files for branch (branch: integration-test/branch-10/target)
🤖 Found 53 files in dir target-branch (branch: integration-test/branch-10/target)
🤖 Which resulted in 33 k8sResources (branch: integration-test/branch-10/target)
🤖 Filtering 18 Application[Sets] (branch: integration-test/branch-10/target)
🤖 Will only run on Applications that watch these files: 'examples/ignore-differences/app.yaml'
🤖 Found 18 Application[Sets] before filtering (branch: integration-test/branch-10/target)
🤖 Found 1 Application[Sets] after filtering (branch: integration-test/branch-10/target)
🤖 Patching 1 Application[Sets] (branch: integration-test/branch-10/target)
🧼 Deleting applications older than 20 minutes
🧼 No applications with the label 'argocd-diff-preview-run-id' were found older than 20 minutes
🦑 Logging in to Argo CD through CLI...
🦑 Logged in to Argo CD successfully
🤖 Converting ApplicationSets to Applications in both branches
🤖 No ApplicationSets found for branch: integration-test/branch-10/base
🤖 Filtering 1 Applications (branch: integration-test/branch-10/base)
🤖 Patching 1 Applications (branch: integration-test/branch-10/base)
🤖 No ApplicationSets found for branch: integration-test/branch-10/target
🤖 Filtering 1 Applications (branch: integration-test/branch-10/target)
🤖 Patching 1 Applications (branch: integration-test/branch-10/target)
🤖 Converting ApplicationSets to Applications in both branches took 1.685584ms
🤖 Getting Applications (timeout in 90 seconds)
🤖 Rendered 0 out of 2 applications (timeout in 85 seconds)
🧼 Waiting for all application deletions to complete...
🧼 All application deletions completed
🤖 Got all resources from 1 applications from base-branch and got 1 from target-branch in 5s
🔮 Generating diff between integration-test/branch-10/base and integration-test/branch-10/target
🙏 Please check the ./output/diff.md and ./output/diff.html files for differences
⏰ Run time stats: [Applications: 2], [Full Run: 6s], [Rendering: 5s], [Cluster: 0s], [Argo CD: 1s]
✨ Total execution time: 6s
```