### PR TITLE
Support password retrieval of ArgoCD Operator

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -358,10 +358,11 @@ func (a *ArgoCDInstallation) getInitialPassword() (string, error) {
 	var err_fallback error
 	secret, err := a.K8sClient.GetSecretValue(a.Namespace, "argocd-initial-admin-secret", "password")
 	if err != nil {
+		log.Debug().Msgf("Failed to get password in 'argocd-initial-admin-secret'. Trying to get fallback password in 'argocd-cluster' secret.") 
 		secret, err_fallback = a.K8sClient.GetSecretValue(a.Namespace, "argocd-cluster", "admin.password")
 		if err_fallback != nil {
-			log.Error().Msgf("❌ Failed to get secret 'argocd-initial-admin-secret': %s", err)
-			log.Error().Msgf("❌ Trying ArgoCD Operator location... Failed to get secret 'argocd-cluster': %s", err_fallback)
+			log.Error().Err(err).Msgf("❌ Failed to get secret 'argocd-initial-admin-secret'")
+			log.Error().Err(err_fallback).Msgf("❌ Failed to get fallback secret 'argocd-cluster'")
 			return "", fmt.Errorf("failed to get secret: %w", err)
 		}
 	}


### PR DESCRIPTION
Lookup the k8s secret of ArgoCD Operator when default secret is not found. This should support users with an ArgoCD instance deployed with the ArgoCD Operator without further documentation.

Closes #252 