### PR TITLE
fixed golangci-lint errors

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -129,11 +129,11 @@ func Parse() *Options {
 			// Check required options
 			errors := opts.CheckRequired()
 			if len(errors) > 0 {
-				var errorMsg = ""
+				var errorMsg strings.Builder
 				for _, err := range errors {
-					errorMsg += fmt.Sprintf("'%s', ", err)
+					fmt.Fprintf(&errorMsg, "'%s', ", err)
 				}
-				return fmt.Errorf("error parsing command line flags: %s", errorMsg)
+				return fmt.Errorf("error parsing command line flags: %s", errorMsg.String())
 			}
 
 			// Configure logging based on debug mode and log format
@@ -150,8 +150,8 @@ func Parse() *Options {
 				}
 			}
 			if opts.LogFormat == "human" {
-				consoleWriter.FormatFieldName = func(i interface{}) string { return fmt.Sprintf("(%s: ", i) }
-				consoleWriter.FormatFieldValue = func(i interface{}) string { return fmt.Sprintf("%s)", i) }
+				consoleWriter.FormatFieldName = func(i any) string { return fmt.Sprintf("(%s: ", i) }
+				consoleWriter.FormatFieldValue = func(i any) string { return fmt.Sprintf("%s)", i) }
 			}
 			log.Logger = log.Output(consoleWriter)
 
@@ -319,7 +319,7 @@ func (o *Options) CheckRequired() []string {
 func (o *Options) ParseSelectors() ([]selector.Selector, error) {
 	var selectors []selector.Selector
 	if o.Selector != "" {
-		for _, s := range strings.Split(o.Selector, ",") {
+		for s := range strings.SplitSeq(o.Selector, ",") {
 			selector, err := selector.FromString(strings.TrimSpace(s))
 			if err != nil {
 				return nil, err

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -198,9 +198,7 @@ func (a *ArgoResource) filterByFilesChanged(filesChanged []string, ignoreInvalid
 
 func (a *ArgoResource) filterByAnnotationWatchPattern(watchPattern string, filesChanged []string, ignoreInvalidWatchPattern bool) (bool, string) {
 
-	patternsList := strings.Split(watchPattern, ",")
-
-	for _, pattern := range patternsList {
+	for pattern := range strings.SplitSeq(watchPattern, ",") {
 		pattern = strings.TrimSpace(pattern)
 
 		log.Debug().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("Checking if files changed matches watch-pattern: %s", pattern)
@@ -222,10 +220,8 @@ func (a *ArgoResource) filterByAnnotationWatchPattern(watchPattern string, files
 
 		log.Debug().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("watch-pattern '%s' is valid. Checking if files changed matches watch-pattern", pattern)
 
-		for _, file := range filesChanged {
-			if regex.MatchString(file) {
-				return true, fmt.Sprintf("files changed matches watch-pattern '%s'", watchPattern)
-			}
+		if slices.ContainsFunc(filesChanged, regex.MatchString) {
+			return true, fmt.Sprintf("files changed matches watch-pattern '%s'", watchPattern)
 		}
 	}
 

--- a/pkg/argoapplication/filter_test.go
+++ b/pkg/argoapplication/filter_test.go
@@ -1,6 +1,7 @@
 package argoapplication
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dag-andersen/argocd-diff-preview/pkg/selector"
@@ -1080,19 +1081,20 @@ spec:
 
 func getMultiSourceYamlApp(t *testing.T, annotation string, paths ...string) *unstructured.Unstructured {
 	var node unstructured.Unstructured
-	yamlText := `
+	var yamlText strings.Builder
+	yamlText.WriteString(`
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
     argocd.argoproj.io/manifest-generate-paths: "` + annotation + `"
 spec:
-  sources:`
+  sources:`)
 	for _, path := range paths {
-		yamlText += `
-    - path: "` + path + `"`
+		yamlText.WriteString(`
+    - path: "` + path + `"`)
 	}
-	if err := yaml.Unmarshal([]byte(yamlText), &node); err != nil {
+	if err := yaml.Unmarshal([]byte(yamlText.String()), &node); err != nil {
 		t.Fatalf("Error unmarshalling YAML: %v", err)
 	}
 	return &node

--- a/pkg/argoapplication/patching_test.go
+++ b/pkg/argoapplication/patching_test.go
@@ -549,7 +549,7 @@ func TestRedirectGenerators(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Parse YAML
-			var node map[string]interface{}
+			var node map[string]any
 			err := yaml.Unmarshal([]byte(tt.yaml), &node)
 			assert.NoError(t, err)
 
@@ -729,7 +729,7 @@ spec:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Parse YAML
-			var node map[string]interface{}
+			var node map[string]any
 			err := yaml.Unmarshal([]byte(tt.yaml), &node)
 			assert.NoError(t, err)
 
@@ -764,7 +764,7 @@ spec:
 
 // normalizeYAML normalizes YAML strings by parsing and re-marshaling
 func normalizeYAML(yamlStr string) string {
-	var node map[string]interface{}
+	var node map[string]any
 	err := yaml.Unmarshal([]byte(yamlStr), &node)
 	if err != nil {
 		return yamlStr

--- a/pkg/diff/format.go
+++ b/pkg/diff/format.go
@@ -190,20 +190,6 @@ func formatDiff(diffs []diffmatchpatch.Diff, contextLines uint, ignorePattern *s
 	return changeInfo{content: buffer.String(), addedLines: addedLines, deletedLines: deletedLines}
 }
 
-// Helper functions for min/max
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 // formatNewFileDiff formats a diff for a new file using the go-git/utils/diff package
 func formatNewFileDiff(content string, contextLines uint, ignorePattern *string) changeInfo {

--- a/pkg/diff/format_test.go
+++ b/pkg/diff/format_test.go
@@ -294,10 +294,10 @@ func TestLargeDiff(t *testing.T) {
 	var newLines []string
 
 	// Create 500 different lines in old and new content
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		oldLines = append(oldLines, fmt.Sprintf("old line %d", i))
 	}
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		newLines = append(newLines, fmt.Sprintf("new line %d", i))
 	}
 

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -110,24 +110,23 @@ func (h *HTMLSection) printHTMLSection() string {
 	rows.Grow(len(h.content) + len(h.commentHeader) + htmlOverhead)
 
 	// Add comment header
-	rows.WriteString(fmt.Sprintf(htmlLine, "comment_line", html.EscapeString(h.commentHeader)))
+	fmt.Fprintf(&rows, htmlLine, "comment_line", html.EscapeString(h.commentHeader))
 
 	// Process content lines
-	lines := strings.Split(h.content, "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(h.content) {
 		if len(line) == 0 {
-			rows.WriteString(fmt.Sprintf(htmlLine, "normal_line", html.EscapeString(line)))
+			fmt.Fprintf(&rows, htmlLine, "normal_line", html.EscapeString(line))
 			continue
 		}
 		switch line[0] {
 		case '@':
-			rows.WriteString(fmt.Sprintf(htmlLine, "comment_line", html.EscapeString(line)))
+			fmt.Fprintf(&rows, htmlLine, "comment_line", html.EscapeString(line))
 		case '-':
-			rows.WriteString(fmt.Sprintf(htmlLine, "removed_line", html.EscapeString(line)))
+			fmt.Fprintf(&rows, htmlLine, "removed_line", html.EscapeString(line))
 		case '+':
-			rows.WriteString(fmt.Sprintf(htmlLine, "added_line", html.EscapeString(line)))
+			fmt.Fprintf(&rows, htmlLine, "added_line", html.EscapeString(line))
 		default:
-			rows.WriteString(fmt.Sprintf(htmlLine, "normal_line", html.EscapeString(line)))
+			fmt.Fprintf(&rows, htmlLine, "normal_line", html.EscapeString(line))
 		}
 	}
 	s = strings.ReplaceAll(s, "%rows%", rows.String())
@@ -136,7 +135,6 @@ func (h *HTMLSection) printHTMLSection() string {
 }
 
 func (h *HTMLOutput) printDiff() string {
-
 	var sectionsDiff strings.Builder
 
 	for _, section := range h.sections {

--- a/pkg/diff/summary.go
+++ b/pkg/diff/summary.go
@@ -25,31 +25,31 @@ func buildSummary(changedFiles []Diff) string {
 		}
 	}
 
-	summaryBuilder.WriteString(fmt.Sprintf("Total: %d files changed\n", addedFilesCount+deletedFilesCount+modifiedFilesCount))
+	fmt.Fprintf(&summaryBuilder, "Total: %d files changed\n", addedFilesCount+deletedFilesCount+modifiedFilesCount)
 
 	if 0 < addedFilesCount {
-		summaryBuilder.WriteString(fmt.Sprintf("\nAdded (%d):\n", addedFilesCount))
+		fmt.Fprintf(&summaryBuilder, "\nAdded (%d):\n", addedFilesCount)
 		for _, diff := range changedFiles {
 			if diff.action == merkletrie.Insert {
-				summaryBuilder.WriteString(fmt.Sprintf("+ %s%s\n", diff.prettyName(), diff.changeStats()))
+				fmt.Fprintf(&summaryBuilder, "+ %s%s\n", diff.prettyName(), diff.changeStats())
 			}
 		}
 	}
 
 	if 0 < deletedFilesCount {
-		summaryBuilder.WriteString(fmt.Sprintf("\nDeleted (%d):\n", deletedFilesCount))
+		fmt.Fprintf(&summaryBuilder, "\nDeleted (%d):\n", deletedFilesCount)
 		for _, diff := range changedFiles {
 			if diff.action == merkletrie.Delete {
-				summaryBuilder.WriteString(fmt.Sprintf("- %s%s\n", diff.prettyName(), diff.changeStats()))
+				fmt.Fprintf(&summaryBuilder, "- %s%s\n", diff.prettyName(), diff.changeStats())
 			}
 		}
 	}
 
 	if 0 < modifiedFilesCount {
-		summaryBuilder.WriteString(fmt.Sprintf("\nModified (%d):\n", modifiedFilesCount))
+		fmt.Fprintf(&summaryBuilder, "\nModified (%d):\n", modifiedFilesCount)
 		for _, diff := range changedFiles {
 			if diff.action == merkletrie.Modify {
-				summaryBuilder.WriteString(fmt.Sprintf("± %s%s\n", diff.prettyName(), diff.changeStats()))
+				fmt.Fprintf(&summaryBuilder, "± %s%s\n", diff.prettyName(), diff.changeStats())
 			}
 		}
 	}

--- a/pkg/duplicates/duplicates_test.go
+++ b/pkg/duplicates/duplicates_test.go
@@ -178,7 +178,7 @@ func TestFilterDuplicates_Performance(t *testing.T) {
 
 	// Create many apps
 	var appsList []argoapplication.ArgoResource
-	for i := 0; i < numApps; i++ {
+	for i := range numApps {
 		app := createTestArgoResource("Application",
 			fmt.Sprintf("app%d", i),
 			fmt.Sprintf("app%d.yaml", i),
@@ -190,7 +190,7 @@ func TestFilterDuplicates_Performance(t *testing.T) {
 
 	// Create duplicates (first half of apps)
 	var duplicates []*unstructured.Unstructured
-	for i := 0; i < numDuplicates; i++ {
+	for i := range numDuplicates {
 		duplicates = append(duplicates, appsList[i].Yaml)
 	}
 

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -188,7 +188,7 @@ func getResourcesFromApps(
 		}
 	}()
 
-	for i := 0; i < len(apps); i++ {
+	for range len(apps) {
 		result := <-results
 		if result.err != nil {
 			if firstError == nil {

--- a/pkg/extract/ignore_differences_test.go
+++ b/pkg/extract/ignore_differences_test.go
@@ -14,33 +14,33 @@ import (
 func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 	tests := []struct {
 		name          string
-		appObj        map[string]interface{}
+		appObj        map[string]any
 		expectedRules []ignoreDifferenceRule
 		expectedCount int
 	}{
 		{
 			name: "Application with spec.ignoreDifferences",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "test-controller",
 					"namespace": "argocd",
 				},
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{
-						map[string]interface{}{
+				"spec": map[string]any{
+					"ignoreDifferences": []any{
+						map[string]any{
 							"group":        "admissionregistration.k8s.io",
 							"kind":         "ValidatingWebhookConfiguration",
 							"name":         "example-webhook-validations",
-							"jsonPointers": []interface{}{"/webhooks/0/clientConfig/caBundle"},
+							"jsonPointers": []any{"/webhooks/0/clientConfig/caBundle"},
 						},
-						map[string]interface{}{
+						map[string]any{
 							"group":        "",
 							"kind":         "Secret",
 							"name":         "example-webhook-ca-keypair",
 							"namespace":    "example-system",
-							"jsonPointers": []interface{}{"/data"},
+							"jsonPointers": []any{"/data"},
 						},
 					},
 				},
@@ -64,20 +64,20 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "ApplicationSet with template.spec.ignoreDifferences",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "ApplicationSet",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "test-appset",
 					"namespace": "argocd",
 				},
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"spec": map[string]interface{}{
-							"ignoreDifferences": []interface{}{
-								map[string]interface{}{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"ignoreDifferences": []any{
+								map[string]any{
 									"kind":         "Deployment",
-									"jsonPointers": []interface{}{"/metadata/annotations"},
+									"jsonPointers": []any{"/metadata/annotations"},
 								},
 							},
 						},
@@ -94,14 +94,14 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "Application with jqPathExpressions",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{
-						map[string]interface{}{
+				"spec": map[string]any{
+					"ignoreDifferences": []any{
+						map[string]any{
 							"kind":              "Deployment",
-							"jqPathExpressions": []interface{}{".spec.template.spec.containers[].image"},
+							"jqPathExpressions": []any{".spec.template.spec.containers[].image"},
 						},
 					},
 				},
@@ -116,15 +116,15 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "Mixed jsonPointers and jqPathExpressions",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{
-						map[string]interface{}{
+				"spec": map[string]any{
+					"ignoreDifferences": []any{
+						map[string]any{
 							"kind":              "Service",
-							"jsonPointers":      []interface{}{"/metadata/labels"},
-							"jqPathExpressions": []interface{}{".spec.ports[].nodePort"},
+							"jsonPointers":      []any{"/metadata/labels"},
+							"jqPathExpressions": []any{".spec.ports[].nodePort"},
 						},
 					},
 				},
@@ -140,11 +140,11 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "Empty ignoreDifferences",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{},
+				"spec": map[string]any{
+					"ignoreDifferences": []any{},
 				},
 			},
 			expectedRules: []ignoreDifferenceRule{},
@@ -152,24 +152,24 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "No ignoreDifferences field",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec":       map[string]interface{}{},
+				"spec":       map[string]any{},
 			},
 			expectedRules: []ignoreDifferenceRule{},
 			expectedCount: 0,
 		},
 		{
 			name: "Invalid rule - missing kind",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{
-						map[string]interface{}{
+				"spec": map[string]any{
+					"ignoreDifferences": []any{
+						map[string]any{
 							"group":        "apps",
-							"jsonPointers": []interface{}{"/metadata/labels"},
+							"jsonPointers": []any{"/metadata/labels"},
 						},
 					},
 				},
@@ -179,12 +179,12 @@ func TestParseIgnoreDifferencesFromApp(t *testing.T) {
 		},
 		{
 			name: "Invalid rule - missing jsonPointers and jqPathExpressions",
-			appObj: map[string]interface{}{
+			appObj: map[string]any{
 				"apiVersion": "argoproj.io/v1alpha1",
 				"kind":       "Application",
-				"spec": map[string]interface{}{
-					"ignoreDifferences": []interface{}{
-						map[string]interface{}{
+				"spec": map[string]any{
+					"ignoreDifferences": []any{
+						map[string]any{
 							"kind": "Deployment",
 						},
 					},
@@ -242,43 +242,43 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "JSON pointer deletion from webhook and secret",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "admissionregistration.k8s.io/v1",
 					"kind":       "ValidatingWebhookConfiguration",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "example-webhook-validations",
 					},
-					"webhooks": []interface{}{
-						map[string]interface{}{
-							"clientConfig": map[string]interface{}{
+					"webhooks": []any{
+						map[string]any{
+							"clientConfig": map[string]any{
 								"caBundle": "SOMEBASE64CERT",
-								"service": map[string]interface{}{
+								"service": map[string]any{
 									"name": "webhook-service",
 								},
 							},
 						},
 					},
 				}},
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Secret",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-webhook-ca-keypair",
 						"namespace": "example-system",
 					},
-					"data": map[string]interface{}{
+					"data": map[string]any{
 						"tls.crt": "BASE64DATA",
 						"tls.key": "BASE64KEY",
 					},
 				}},
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Secret",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "other-secret",
 						"namespace": "example-system",
 					},
-					"data": map[string]interface{}{
+					"data": map[string]any{
 						"password": "abc",
 					},
 				}},
@@ -304,7 +304,7 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, foundSlice)
 				require.GreaterOrEqual(t, len(webhooks), 1)
-				firstWebhook, ok := webhooks[0].(map[string]interface{})
+				firstWebhook, ok := webhooks[0].(map[string]any)
 				require.True(t, ok)
 
 				// caBundle should be gone
@@ -334,21 +334,21 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "Array element masking with JSON pointer",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-deployment",
 					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "app",
 										"image": "nginx:1.20",
 									},
-									map[string]interface{}{
+									map[string]any{
 										"name":  "sidecar",
 										"image": "busybox:latest",
 									},
@@ -371,7 +371,7 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 				require.Len(t, containers, 2)
 
 				// First container should be unchanged
-				firstContainer, ok := containers[0].(map[string]interface{})
+				firstContainer, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", firstContainer["name"])
 				assert.Equal(t, "nginx:1.20", firstContainer["image"])
@@ -383,13 +383,13 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "No matching rules",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-config",
 					},
-					"data": map[string]interface{}{
+					"data": map[string]any{
 						"key": "value",
 					},
 				}},
@@ -411,10 +411,10 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "Empty rules",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Secret",
-					"data": map[string]interface{}{
+					"data": map[string]any{
 						"key": "value",
 					},
 				}},
@@ -431,21 +431,21 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "Multiple JSON pointers on same resource",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Service",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-service",
-						"labels": map[string]interface{}{
+						"labels": map[string]any{
 							"app": "test",
 						},
-						"annotations": map[string]interface{}{
+						"annotations": map[string]any{
 							"key": "value",
 						},
 					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
 								"port":     80,
 								"nodePort": 30080,
 							},
@@ -477,7 +477,7 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 				require.True(t, found)
 				require.Len(t, ports, 1)
 
-				firstPort, ok := ports[0].(map[string]interface{})
+				firstPort, ok := ports[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, int64(80), firstPort["port"])
 				_, exists := firstPort["nodePort"]
@@ -487,27 +487,27 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 		{
 			name: "Group matching with core group",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Pod",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-pod",
 					},
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
 								"name": "app",
 							},
 						},
 					},
 				}},
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-deployment",
 					},
-					"spec": map[string]interface{}{
+					"spec": map[string]any{
 						"replicas": 3,
 					},
 				}},
@@ -544,7 +544,7 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 			manifestsCopy := make([]unstructured.Unstructured, len(tt.manifests))
 			for i, m := range tt.manifests {
 				manifestsCopy[i] = unstructured.Unstructured{
-					Object: deepCopyValue(m.Object).(map[string]interface{}),
+					Object: deepCopyValue(m.Object).(map[string]any),
 				}
 			}
 
@@ -558,23 +558,23 @@ func TestApplyIgnoreDifferencesToManifests(t *testing.T) {
 func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 	tests := []struct {
 		name     string
-		obj      map[string]interface{}
+		obj      map[string]any
 		pointer  string
-		validate func(t *testing.T, obj map[string]interface{})
+		validate func(t *testing.T, obj map[string]any)
 	}{
 		{
 			name: "Delete simple key",
-			obj: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			obj: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
-					"labels": map[string]interface{}{
+					"labels": map[string]any{
 						"app": "myapp",
 					},
 				},
 			},
 			pointer: "/metadata/labels",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				metadata, ok := obj["metadata"].(map[string]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				metadata, ok := obj["metadata"].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "test", metadata["name"])
 				_, exists := metadata["labels"]
@@ -583,12 +583,12 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Delete nested key",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"spec": map[string]interface{}{
-							"containers": []interface{}{
-								map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
 									"name":  "app",
 									"image": "nginx",
 								},
@@ -598,7 +598,7 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 				},
 			},
 			pointer: "/spec/template/spec",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				template, found, err := unstructured.NestedMap(obj, "spec", "template")
 				require.NoError(t, err)
 				require.True(t, found)
@@ -608,16 +608,16 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Mask array element",
-			obj: map[string]interface{}{
-				"items": []interface{}{
+			obj: map[string]any{
+				"items": []any{
 					"first",
 					"second",
 					"third",
 				},
 			},
 			pointer: "/items/1",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				items, ok := obj["items"].([]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				items, ok := obj["items"].([]any)
 				require.True(t, ok)
 				require.Len(t, items, 3)
 				assert.Equal(t, "first", items[0])
@@ -627,17 +627,17 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Mask nested array element",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []interface{}{
-						map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
 							"name": "app",
-							"env": []interface{}{
-								map[string]interface{}{
+							"env": []any{
+								map[string]any{
 									"name":  "VAR1",
 									"value": "val1",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"name":  "VAR2",
 									"value": "val2",
 								},
@@ -647,20 +647,20 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 				},
 			},
 			pointer: "/spec/containers/0/env/1",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				containers, ok := obj["spec"].(map[string]interface{})["containers"].([]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				containers, ok := obj["spec"].(map[string]any)["containers"].([]any)
 				require.True(t, ok)
 				require.Len(t, containers, 1)
 
-				container, ok := containers[0].(map[string]interface{})
+				container, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", container["name"])
 
-				env, ok := container["env"].([]interface{})
+				env, ok := container["env"].([]any)
 				require.True(t, ok)
 				require.Len(t, env, 2)
 
-				firstEnv, ok := env[0].(map[string]interface{})
+				firstEnv, ok := env[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "VAR1", firstEnv["name"])
 				assert.Equal(t, "val1", firstEnv["value"])
@@ -670,46 +670,46 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Invalid pointer - no leading slash",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"key": "value",
 			},
 			pointer: "key",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
 				assert.Equal(t, "value", obj["key"])
 			},
 		},
 		{
 			name: "Invalid pointer - empty string",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"key": "value",
 			},
 			pointer: "",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
 				assert.Equal(t, "value", obj["key"])
 			},
 		},
 		{
 			name: "Nonexistent path",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"existing": "value",
 			},
 			pointer: "/nonexistent/path",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
 				assert.Equal(t, "value", obj["existing"])
 			},
 		},
 		{
 			name: "Array index out of bounds",
-			obj: map[string]interface{}{
-				"items": []interface{}{"one", "two"},
+			obj: map[string]any{
+				"items": []any{"one", "two"},
 			},
 			pointer: "/items/5",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
-				items, ok := obj["items"].([]interface{})
+				items, ok := obj["items"].([]any)
 				require.True(t, ok)
 				assert.Len(t, items, 2)
 				assert.Equal(t, "one", items[0])
@@ -718,13 +718,13 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Array index negative",
-			obj: map[string]interface{}{
-				"items": []interface{}{"one", "two"},
+			obj: map[string]any{
+				"items": []any{"one", "two"},
 			},
 			pointer: "/items/-1",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
-				items, ok := obj["items"].([]interface{})
+				items, ok := obj["items"].([]any)
 				require.True(t, ok)
 				assert.Len(t, items, 2)
 				assert.Equal(t, "one", items[0])
@@ -733,14 +733,14 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "JSON pointer escaping",
-			obj: map[string]interface{}{
-				"path/with~slash": map[string]interface{}{
+			obj: map[string]any{
+				"path/with~slash": map[string]any{
 					"nested~key": "value",
 				},
 			},
 			pointer: "/path~1with~0slash/nested~0key",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				parent, ok := obj["path/with~slash"].(map[string]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				parent, ok := obj["path/with~slash"].(map[string]any)
 				require.True(t, ok)
 				_, exists := parent["nested~key"]
 				assert.False(t, exists)
@@ -748,19 +748,19 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 		},
 		{
 			name: "Root level deletion",
-			obj: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			obj: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"replicas": 3,
 				},
 			},
 			pointer: "/metadata",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				_, exists := obj["metadata"]
 				assert.False(t, exists)
-				assert.Equal(t, int64(3), obj["spec"].(map[string]interface{})["replicas"])
+				assert.Equal(t, int64(3), obj["spec"].(map[string]any)["replicas"])
 			},
 		},
 	}
@@ -768,7 +768,7 @@ func TestDeleteOrMaskAtJSONPointer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Make a deep copy to avoid test interference
-			objCopy := make(map[string]interface{})
+			objCopy := make(map[string]any)
 			for k, v := range tt.obj {
 				objCopy[k] = deepCopyValue(v)
 			}
@@ -826,16 +826,16 @@ func TestDecodeJSONPointerToken(t *testing.T) {
 }
 
 // Helper function for deep copying values
-func deepCopyValue(v interface{}) interface{} {
+func deepCopyValue(v any) any {
 	switch val := v.(type) {
-	case map[string]interface{}:
-		copy := make(map[string]interface{})
+	case map[string]any:
+		copy := make(map[string]any)
 		for k, v := range val {
 			copy[k] = deepCopyValue(v)
 		}
 		return copy
-	case []interface{}:
-		copy := make([]interface{}, len(val))
+	case []any:
+		copy := make([]any, len(val))
 		for i, v := range val {
 			copy[i] = deepCopyValue(v)
 		}
@@ -968,23 +968,23 @@ func TestGroupFromAPIVersion(t *testing.T) {
 func TestApplyJQPathExpression(t *testing.T) {
 	tests := []struct {
 		name     string
-		obj      map[string]interface{}
+		obj      map[string]any
 		expr     string
-		validate func(t *testing.T, obj map[string]interface{})
+		validate func(t *testing.T, obj map[string]any)
 	}{
 		{
 			name: "Simple field selection",
-			obj: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			obj: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
-					"labels": map[string]interface{}{
+					"labels": map[string]any{
 						"app": "myapp",
 					},
 				},
 			},
 			expr: ".metadata.labels",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				metadata, ok := obj["metadata"].(map[string]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				metadata, ok := obj["metadata"].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "test", metadata["name"])
 				_, exists := metadata["labels"]
@@ -993,14 +993,14 @@ func TestApplyJQPathExpression(t *testing.T) {
 		},
 		{
 			name: "Array element selection",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []interface{}{
-						map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
 							"name":  "app",
 							"image": "nginx:1.20",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":  "sidecar",
 							"image": "busybox:latest",
 						},
@@ -1008,13 +1008,13 @@ func TestApplyJQPathExpression(t *testing.T) {
 				},
 			},
 			expr: ".spec.containers[1]",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				containers, found, err := unstructured.NestedSlice(obj, "spec", "containers")
 				require.NoError(t, err)
 				require.True(t, found)
 				require.Len(t, containers, 2)
 
-				firstContainer, ok := containers[0].(map[string]interface{})
+				firstContainer, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", firstContainer["name"])
 
@@ -1023,14 +1023,14 @@ func TestApplyJQPathExpression(t *testing.T) {
 		},
 		{
 			name: "Array slice with all elements",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []interface{}{
-						map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
 							"name":  "app",
 							"image": "nginx:1.20",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"name":  "sidecar",
 							"image": "busybox:latest",
 						},
@@ -1038,20 +1038,20 @@ func TestApplyJQPathExpression(t *testing.T) {
 				},
 			},
 			expr: ".spec.containers[].image",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				containers, found, err := unstructured.NestedSlice(obj, "spec", "containers")
 				require.NoError(t, err)
 				require.True(t, found)
 				require.Len(t, containers, 2)
 
 				// Both containers should have their image fields removed
-				firstContainer, ok := containers[0].(map[string]interface{})
+				firstContainer, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", firstContainer["name"])
 				_, exists := firstContainer["image"]
 				assert.False(t, exists)
 
-				secondContainer, ok := containers[1].(map[string]interface{})
+				secondContainer, ok := containers[1].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "sidecar", secondContainer["name"])
 				_, exists = secondContainer["image"]
@@ -1060,17 +1060,17 @@ func TestApplyJQPathExpression(t *testing.T) {
 		},
 		{
 			name: "Nested field selection",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"labels": map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]any{
 								"app": "test",
 							},
 						},
-						"spec": map[string]interface{}{
-							"containers": []interface{}{
-								map[string]interface{}{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
 									"name": "app",
 								},
 							},
@@ -1079,7 +1079,7 @@ func TestApplyJQPathExpression(t *testing.T) {
 				},
 			},
 			expr: ".spec.template.metadata.labels",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				metadata, found, err := unstructured.NestedMap(obj, "spec", "template", "metadata")
 				require.NoError(t, err)
 				require.True(t, found)
@@ -1095,53 +1095,53 @@ func TestApplyJQPathExpression(t *testing.T) {
 		},
 		{
 			name: "Invalid jq expression",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"key": "value",
 			},
 			expr: ".invalid[syntax",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged due to invalid expression
 				assert.Equal(t, "value", obj["key"])
 			},
 		},
 		{
 			name: "Empty expression",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"key": "value",
 			},
 			expr: "",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged
 				assert.Equal(t, "value", obj["key"])
 			},
 		},
 		{
 			name: "Expression with no matches",
-			obj: map[string]interface{}{
-				"metadata": map[string]interface{}{
+			obj: map[string]any{
+				"metadata": map[string]any{
 					"name": "test",
 				},
 			},
 			expr: ".spec.containers",
-			validate: func(t *testing.T, obj map[string]interface{}) {
+			validate: func(t *testing.T, obj map[string]any) {
 				// Should remain unchanged since path doesn't exist
-				assert.Equal(t, "test", obj["metadata"].(map[string]interface{})["name"])
+				assert.Equal(t, "test", obj["metadata"].(map[string]any)["name"])
 			},
 		},
 		{
 			name: "Complex jq expression with select",
-			obj: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []interface{}{
-						map[string]interface{}{
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
 							"name":  "app",
 							"image": "nginx:1.20",
-							"ports": []interface{}{
-								map[string]interface{}{
+							"ports": []any{
+								map[string]any{
 									"containerPort": 80,
 									"name":          "http",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"containerPort": 443,
 									"name":          "https",
 								},
@@ -1151,28 +1151,28 @@ func TestApplyJQPathExpression(t *testing.T) {
 				},
 			},
 			expr: ".spec.containers[0].ports[].containerPort",
-			validate: func(t *testing.T, obj map[string]interface{}) {
-				containers, ok := obj["spec"].(map[string]interface{})["containers"].([]interface{})
+			validate: func(t *testing.T, obj map[string]any) {
+				containers, ok := obj["spec"].(map[string]any)["containers"].([]any)
 				require.True(t, ok)
 				require.Len(t, containers, 1)
 
-				container, ok := containers[0].(map[string]interface{})
+				container, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", container["name"])
 				assert.Equal(t, "nginx:1.20", container["image"])
 
-				ports, ok := container["ports"].([]interface{})
+				ports, ok := container["ports"].([]any)
 				require.True(t, ok)
 				require.Len(t, ports, 2)
 
 				// Both ports should have containerPort removed but name should remain
-				firstPort, ok := ports[0].(map[string]interface{})
+				firstPort, ok := ports[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "http", firstPort["name"])
 				_, exists := firstPort["containerPort"]
 				assert.False(t, exists)
 
-				secondPort, ok := ports[1].(map[string]interface{})
+				secondPort, ok := ports[1].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "https", secondPort["name"])
 				_, exists = secondPort["containerPort"]
@@ -1184,7 +1184,7 @@ func TestApplyJQPathExpression(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Make a deep copy to avoid test interference
-			objCopy := make(map[string]interface{})
+			objCopy := make(map[string]any)
 			for k, v := range tt.obj {
 				objCopy[k] = deepCopyValue(v)
 			}
@@ -1205,21 +1205,21 @@ func TestApplyIgnoreDifferencesWithJQPathExpressions(t *testing.T) {
 		{
 			name: "JQ path expression on deployment containers",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-deployment",
 					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"containers": []any{
+									map[string]any{
 										"name":  "app",
 										"image": "nginx:1.20",
 									},
-									map[string]interface{}{
+									map[string]any{
 										"name":  "sidecar",
 										"image": "busybox:latest",
 									},
@@ -1242,13 +1242,13 @@ func TestApplyIgnoreDifferencesWithJQPathExpressions(t *testing.T) {
 				require.Len(t, containers, 2)
 
 				// Both containers should have image removed but names should remain
-				firstContainer, ok := containers[0].(map[string]interface{})
+				firstContainer, ok := containers[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "app", firstContainer["name"])
 				_, exists := firstContainer["image"]
 				assert.False(t, exists)
 
-				secondContainer, ok := containers[1].(map[string]interface{})
+				secondContainer, ok := containers[1].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "sidecar", secondContainer["name"])
 				_, exists = secondContainer["image"]
@@ -1258,22 +1258,22 @@ func TestApplyIgnoreDifferencesWithJQPathExpressions(t *testing.T) {
 		{
 			name: "Mixed JSON pointers and JQ path expressions",
 			manifests: []unstructured.Unstructured{
-				{Object: map[string]interface{}{
+				{Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Service",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "test-service",
-						"labels": map[string]interface{}{
+						"labels": map[string]any{
 							"app": "test",
 						},
 					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
 								"port":     80,
 								"nodePort": 30080,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"port":     443,
 								"nodePort": 30443,
 							},
@@ -1295,19 +1295,19 @@ func TestApplyIgnoreDifferencesWithJQPathExpressions(t *testing.T) {
 				assert.False(t, found)
 
 				// NodePorts should be removed by JQ expression but ports should remain
-				spec, ok := manifests[0].Object["spec"].(map[string]interface{})
+				spec, ok := manifests[0].Object["spec"].(map[string]any)
 				require.True(t, ok)
-				ports, ok := spec["ports"].([]interface{})
+				ports, ok := spec["ports"].([]any)
 				require.True(t, ok)
 				require.Len(t, ports, 2)
 
-				firstPort, ok := ports[0].(map[string]interface{})
+				firstPort, ok := ports[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, 80, firstPort["port"])
 				_, exists := firstPort["nodePort"]
 				assert.False(t, exists)
 
-				secondPort, ok := ports[1].(map[string]interface{})
+				secondPort, ok := ports[1].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, 443, secondPort["port"])
 				_, exists = secondPort["nodePort"]
@@ -1322,7 +1322,7 @@ func TestApplyIgnoreDifferencesWithJQPathExpressions(t *testing.T) {
 			manifestsCopy := make([]unstructured.Unstructured, len(tt.manifests))
 			for i, m := range tt.manifests {
 				manifestsCopy[i] = unstructured.Unstructured{
-					Object: deepCopyValue(m.Object).(map[string]interface{}),
+					Object: deepCopyValue(m.Object).(map[string]any),
 				}
 			}
 

--- a/pkg/extract/process_yaml.go
+++ b/pkg/extract/process_yaml.go
@@ -20,7 +20,7 @@ func processYamlOutput(chunk string) ([]unstructured.Unstructured, error) {
 	for _, doc := range documents {
 
 		// Create a new map to hold the parsed YAML
-		var yamlObj map[string]interface{}
+		var yamlObj map[string]any
 		err := yaml.Unmarshal([]byte(doc), &yamlObj)
 		if err != nil {
 			log.Debug().Msgf("Failed to parse YAML: \n%s", doc)

--- a/pkg/extract/process_yaml_test.go
+++ b/pkg/extract/process_yaml_test.go
@@ -2,6 +2,7 @@ package extract
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -342,20 +343,21 @@ data:
 func TestProcessYamlOutput_EdgeCases(t *testing.T) {
 	t.Run("very large manifest", func(t *testing.T) {
 		// Create a manifest with many labels
-		input := `apiVersion: v1
+		var input strings.Builder
+		input.WriteString(`apiVersion: v1
 kind: ConfigMap
 metadata:
   name: large-config
-  labels:`
+  labels:`)
 
 		// Add many labels to test performance
-		for i := 0; i < 100; i++ {
-			input += "\n    label" + fmt.Sprintf("%d", i) + ": value" + fmt.Sprintf("%d", i)
+		for i := range 100 {
+			fmt.Fprintf(&input, "\n    label%d: value%d", i, i)
 		}
 
-		input += "\ndata:\n  key: value"
+		input.WriteString("\ndata:\n  key: value")
 
-		result, err := processYamlOutput(input)
+		result, err := processYamlOutput(input.String())
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 

--- a/pkg/fileparsing/changed_files.go
+++ b/pkg/fileparsing/changed_files.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -64,12 +65,7 @@ var ignoreFolders = []string{
 
 // shouldIgnoreFolder checks if a folder should be ignored based on its name
 func shouldIgnoreFolder(folderName string) bool {
-	for _, ignoreFolder := range ignoreFolders {
-		if folderName == ignoreFolder {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ignoreFolders, folderName)
 }
 
 // getDirectoryHashes recursively walks a directory and returns a map of relative file paths to their SHA-256 hashes

--- a/pkg/fileparsing/parser.go
+++ b/pkg/fileparsing/parser.go
@@ -127,7 +127,7 @@ func processYamlChunk(filename, chunk string, branch git.BranchType) (*Resource,
 	}
 
 	// Create a new map to hold the parsed YAML
-	var yamlObj map[string]interface{}
+	var yamlObj map[string]any
 	err := yaml.Unmarshal([]byte(chunk), &yamlObj)
 	if err != nil {
 		log.Debug().Err(err).Msgf("⚠️ Failed to parse YAML in file '%s'", filename)

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -85,8 +85,7 @@ func ClusterExists(clusterName string) bool {
 		return false
 	}
 
-	clusters := strings.Split(strings.TrimSpace(output), "\n")
-	for _, cluster := range clusters {
+	for cluster := range strings.Lines(strings.TrimSpace(output)) {
 		if cluster == clusterName {
 			return true
 		}

--- a/pkg/utils/k8s-client.go
+++ b/pkg/utils/k8s-client.go
@@ -463,8 +463,8 @@ func (c *K8sClient) CreateNamespace(namespace string) (bool, error) {
 
 	// Namespace doesn't exist, create it
 	_, err = c.clientSet.Resource(namespaceRes).Create(context.Background(), &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"name": namespace,
 			},
 		},
@@ -521,7 +521,7 @@ func (c *K8sClient) GetSecretValue(namespace string, name string, key string) (s
 	}
 
 	// get value from path
-	value, ok := result.Object["data"].(map[string]interface{})[key]
+	value, ok := result.Object["data"].(map[string]any)[key]
 	if !ok {
 		return "", fmt.Errorf("key %s not found in secret %s", key, name)
 	}
@@ -643,7 +643,7 @@ func (c *K8sClient) WaitForDeploymentReady(namespace, name string, timeoutSecond
 				// Check for Available condition
 				isAvailable := false
 				for _, conditionUnstructured := range conditions {
-					condition, ok := conditionUnstructured.(map[string]interface{})
+					condition, ok := conditionUnstructured.(map[string]any)
 					if !ok {
 						continue
 					}


### PR DESCRIPTION
I have addressed several issues flagged by the [modernize analyzer](https://github.com/golang/go/issues/75266#issuecomment-3335717523).

1. String Builder Optimization (QF1012)
2. Interface{} to Any Replacement
3. String Sequence Optimization (stringsseq)
4. Slices Contains Simplification
5. Min/Max Built-in Functions
6. Range Over Int (Go 1.22)