### PR TITLE
Feat | Support diffs with live environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ Instead of spinning up an ephemeral cluster for each diff preview, you can conne
 
 Rendering manifests for all applications in your repository on every pull request can be time-consuming, especially in large monorepos. By default, `argocd-diff-preview` renders all applications it finds, but you can significantly speed up the process by limiting which applications are rendered. Refer to the [Application Selection](https://dag-andersen.github.io/argocd-diff-preview/application-selection/) section in the docs to learn how to do this.
 
+### Compare against live Argo CD
+
+If you want to compare the pull request output against the live state of a remote Argo CD instance, enable live comparison mode:
+
+```bash
+argocd-diff-preview \
+  --compare-live \
+  --live-argocd-url https://argocd.example.com \
+  --live-argocd-token "$ARGOCD_READ_TOKEN" \
+  --target-branch feature \
+  --repo my-org/my-repo
+```
+
+If the Argo CD server uses a self-signed certificate, add `--live-argocd-insecure` to skip TLS verification.
+
 ## Full Documentation
 
 [Link to docs](https://dag-andersen.github.io/argocd-diff-preview/)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dag-andersen/argocd-diff-preview/pkg/app_selector"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/argoapplication"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/argocd"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/diff"
@@ -48,6 +49,14 @@ func main() {
 }
 
 func run(cfg *Config) error {
+	// Use live comparison mode if enabled
+	if cfg.CompareLive {
+		return runLiveComparison(cfg)
+	}
+	return runStandardComparison(cfg)
+}
+
+func runStandardComparison(cfg *Config) error {
 	startTime := time.Now()
 
 	// Get values directly from the config - no getters needed
@@ -401,4 +410,444 @@ func convertExtractedAppsToAppInfos(extractedApps []extract.ExtractedApp, ignore
 		}
 	}
 	return appInfos, nil
+}
+
+type remoteArgoCDClient interface {
+	MatchApplicationsByName(targetAppNames []string) (map[string]string, []string, error)
+	FetchLiveManifestsForApps(appNames []string) ([]argocd.LiveAppManifest, error)
+}
+
+type liveComparisonDeps struct {
+	listChangedFiles      func(folder1 string, folder2 string) ([]string, time.Duration, error)
+	createFolder          func(path string, clear bool) error
+	writeNoAppsFound      func(title string, outputFolder string, selectors []app_selector.Selector, changedFiles []string) error
+	newRemoteArgoCD       func(url string, token string, insecure bool) remoteArgoCDClient
+	newK8sClient          func() (*utils.K8sClient, error)
+	deleteOldApplications func(client *utils.K8sClient, namespace string, ageInMinutes int) error
+	newLocalArgoCD        func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation
+	installArgoCD         func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error)
+	loginArgoCD           func(argocd *argocd.ArgoCDInstallation) (time.Duration, error)
+	convertAppSets        func(argocd *argocd.ArgoCDInstallation, apps *argoapplication.ArgoSelection, branch *git.Branch, repo string, tempFolder string, redirectRevisions []string, debug bool, appSelectionOptions argoapplication.ApplicationSelectionOptions) (*argoapplication.ArgoSelection, time.Duration, error)
+	renderApps            func(argocd *argocd.ArgoCDInstallation, timeout uint64, baseApps []argoapplication.ArgoResource, targetApps []argoapplication.ArgoResource, prefix string, deleteAfterProcessing bool) ([]extract.ExtractedApp, []extract.ExtractedApp, time.Duration, error)
+	generateDiff          func(title string, outputFolder string, baseBranch *git.Branch, targetBranch *git.Branch, baseApps []diff.AppInfo, targetApps []diff.AppInfo, diffIgnoreRegex *string, lineCount uint, maxCharCount uint, hideDeletedAppDiff bool, statsInfo diff.StatsInfo, selectionInfo diff.SelectionInfo) error
+}
+
+func defaultLiveComparisonDeps() liveComparisonDeps {
+	return liveComparisonDeps{
+		listChangedFiles:      fileparsing.ListChangedFiles,
+		createFolder:          utils.CreateFolder,
+		writeNoAppsFound:      diff.WriteNoAppsFoundMessage,
+		newRemoteArgoCD:       func(url string, token string, insecure bool) remoteArgoCDClient { return argocd.NewRemoteArgoCD(url, token, insecure) },
+		newK8sClient:          utils.NewK8sClient,
+		deleteOldApplications: func(client *utils.K8sClient, namespace string, ageInMinutes int) error { return client.DeleteAllApplicationsOlderThan(namespace, ageInMinutes) },
+		newLocalArgoCD: func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation {
+			return argocd.New(
+				client,
+				cfg.ArgocdNamespace,
+				cfg.ArgocdChartVersion,
+				cfg.ArgocdChartName,
+				cfg.ArgocdChartURL,
+				cfg.ArgocdChartRepoUsername,
+				cfg.ArgocdChartRepoPassword,
+				cfg.ArgocdLoginOptions,
+			)
+		},
+		installArgoCD:  func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error) { return argocd.Install(debug, secretsFolder) },
+		loginArgoCD:    func(argocd *argocd.ArgoCDInstallation) (time.Duration, error) { return argocd.OnlyLogin() },
+		convertAppSets: argoapplication.ConvertAppSetsToAppsInBranch,
+		renderApps:     extract.RenderApplicaitonsFromBothBranches,
+		generateDiff:   diff.GenerateDiff,
+	}
+}
+
+// runLiveComparison runs the diff comparing target branch against live state from remote ArgoCD
+func runLiveComparison(cfg *Config) error {
+	return runLiveComparisonWithDeps(cfg, defaultLiveComparisonDeps())
+}
+
+func runLiveComparisonWithDeps(cfg *Config, deps liveComparisonDeps) error {
+	startTime := time.Now()
+
+	log.Info().Msg("🌐 Running in live comparison mode - comparing PR against remote ArgoCD")
+
+	// Get values directly from the config
+	fileRegex := cfg.FileRegex
+	selectors := cfg.Selectors
+	filesChanged := cfg.FilesChanged
+	redirectRevisions := cfg.RedirectRevisions
+	clusterProvider := cfg.ClusterProvider
+
+	// Create unique ID
+	uniqueID := uuid.New().String()[:5]
+
+	if !cfg.CreateCluster && !cfg.DryRun {
+		log.Info().Msgf("🔑 Unique ID for this run: %s", uniqueID)
+	}
+
+	// Create target branch (no base branch in live mode)
+	targetBranch := git.NewBranch(cfg.TargetBranch, git.Target)
+	// Create a "live" branch for diff output naming
+	liveBranch := git.NewBranch("live", git.Live)
+
+	if cfg.AutoDetectFilesChanged && len(filesChanged) == 0 {
+		if cfg.BaseBranch == "" {
+			log.Warn().Msg("⚠️ Auto-detect-files-changed is enabled but base-branch is empty; skipping auto-detect")
+		} else {
+			log.Info().Msg("🔍 Auto-detecting changed files")
+			baseBranch := git.NewBranch(cfg.BaseBranch, git.Base)
+			cf, duration, err := deps.listChangedFiles(baseBranch.FolderName(), targetBranch.FolderName())
+			if err != nil {
+				log.Error().Msgf("❌ Failed to auto-detect changed files: %s", err)
+				return err
+			}
+			log.Info().Msgf("🔍 Found %d changed files in %s", len(cf), duration.Round(time.Second))
+			filesChanged = cf
+		}
+	}
+
+	// Check if users limited the Application Selection
+	searchIsLimited := len(selectors) > 0 || len(filesChanged) > 0 || fileRegex != nil
+
+	appSelectionOptions := argoapplication.ApplicationSelectionOptions{
+		Selector:                   selectors,
+		FileRegex:                  fileRegex,
+		FilesChanged:               filesChanged,
+		IgnoreInvalidWatchPattern:  cfg.IgnoreInvalidWatchPattern,
+		WatchIfNoWatchPatternFound: cfg.WatchIfNoWatchPatternFound,
+	}
+
+	// Get applications only from target branch
+	targetApps, err := argoapplication.GetApplicationsForBranch(
+		cfg.ArgocdNamespace,
+		targetBranch,
+		appSelectionOptions,
+		cfg.Repo,
+		redirectRevisions,
+	)
+	if err != nil {
+		log.Error().Msgf("❌ Failed to get applications from target branch")
+		return err
+	}
+
+	// If dry-run is enabled, show which applications would be processed and exit
+	if cfg.DryRun {
+		log.Info().Msg("💨 This is a dry run (live comparison mode). The following applications would be processed:")
+
+		if len(targetApps.SelectedApps) > 0 {
+			log.Info().Msgf("👇 Target Branch ('%s'):", targetBranch.Name)
+			for _, app := range targetApps.SelectedApps {
+				log.Info().Msgf("  - %s: %s (%s)", app.Kind.ShortName(), app.Name, app.FileName)
+			}
+		} else {
+			log.Info().Msgf("🤷 No applications selected for the target branch ('%s').", targetBranch.Name)
+		}
+
+		log.Info().Msg("✅ Dry run complete. No cluster was created and no diff was generated.")
+		return nil
+	}
+
+	// Return if no applications are found
+	if len(targetApps.SelectedApps) == 0 {
+		log.Info().Msg("👀 Found no applications to process in target branch")
+
+		if err := deps.createFolder(cfg.OutputFolder, true); err != nil {
+			log.Error().Msgf("❌ Failed to create output folder: %s", cfg.OutputFolder)
+			return err
+		}
+
+		if err := deps.writeNoAppsFound(cfg.Title, cfg.OutputFolder, selectors, filesChanged); err != nil {
+			log.Error().Msgf("❌ Failed to write no apps found message")
+			return err
+		}
+
+		return nil
+	}
+
+	// Connect to remote ArgoCD
+	remoteArgoCD := deps.newRemoteArgoCD(cfg.LiveArgocdURL, cfg.LiveArgocdToken, cfg.LiveArgocdInsecure)
+
+	var clusterCreationDuration time.Duration
+	if cfg.CreateCluster {
+		duration, err := clusterProvider.CreateCluster()
+		if err != nil {
+			log.Error().Msgf("❌ Failed to create cluster")
+			return err
+		}
+		clusterCreationDuration = duration
+	}
+
+	defer func() {
+		if cfg.CreateCluster {
+			if !cfg.KeepClusterAlive {
+				clusterProvider.DeleteCluster(true)
+			} else {
+				log.Info().Msg("🧟‍♂️ Cluster will be kept alive after the tool finishes")
+			}
+		}
+	}()
+
+	// Create k8s client
+	k8sClient, err := deps.newK8sClient()
+	if err != nil {
+		log.Error().Err(err).Msgf("❌ Failed to create k8s client")
+		return err
+	}
+
+	// Delete old applications
+	if !cfg.CreateCluster {
+		ageInMinutes := 20
+		if err := deps.deleteOldApplications(k8sClient, cfg.ArgocdNamespace, ageInMinutes); err != nil {
+			log.Error().Msgf("❌ Failed to delete old applications")
+			return err
+		}
+	}
+
+	localArgoCD := deps.newLocalArgoCD(k8sClient, cfg)
+
+	var argocdInstallationDuration time.Duration
+	if cfg.CreateCluster {
+		duration, err := deps.installArgoCD(localArgoCD, cfg.Debug, cfg.SecretsFolder)
+		if err != nil {
+			log.Error().Msgf("❌ Failed to install Argo CD")
+			return err
+		}
+		argocdInstallationDuration = duration
+	} else {
+		duration, err := deps.loginArgoCD(localArgoCD)
+		if err != nil {
+			log.Error().Msgf("❌ Failed to login to Argo CD")
+			return err
+		}
+		argocdInstallationDuration = duration
+	}
+
+	tempFolder := "temp"
+	if err := deps.createFolder(tempFolder, true); err != nil {
+		log.Error().Msgf("❌ Failed to clear temp folder: ./%s", tempFolder)
+		return err
+	}
+
+	// Convert ApplicationSets to Applications for target branch only
+	targetApps, convertAppSetsToAppsDuration, err := deps.convertAppSets(
+		localArgoCD,
+		targetApps,
+		targetBranch,
+		cfg.Repo,
+		tempFolder,
+		redirectRevisions,
+		cfg.Debug,
+		appSelectionOptions,
+	)
+	if err != nil {
+		log.Error().Msgf("❌ Failed to generate apps from ApplicationSets")
+		return err
+	}
+
+	// Return if no applications are found after conversion
+	if len(targetApps.SelectedApps) == 0 {
+		log.Info().Msg("👀 Found no applications to render")
+
+		if err := deps.createFolder(cfg.OutputFolder, true); err != nil {
+			log.Error().Msgf("❌ Failed to create output folder: %s", cfg.OutputFolder)
+			return err
+		}
+
+		if err := deps.writeNoAppsFound(cfg.Title, cfg.OutputFolder, selectors, filesChanged); err != nil {
+			log.Error().Msgf("❌ Failed to write no apps found message")
+			return err
+		}
+
+		return nil
+	}
+
+	// Ensure unique IDs for target apps
+	targetApps.SelectedApps = argoapplication.UniqueIds(targetApps.SelectedApps, targetBranch)
+
+	// Match target apps to live apps by name (after appset conversion)
+	targetAppNames := make([]string, len(targetApps.SelectedApps))
+	for i, app := range targetApps.SelectedApps {
+		targetAppNames[i] = app.Name
+	}
+
+	matchedApps, newApps, err := remoteArgoCD.MatchApplicationsByName(targetAppNames)
+	if err != nil {
+		log.Error().Msgf("❌ Failed to match applications with live ArgoCD")
+		return err
+	}
+
+	if len(newApps) > 0 {
+		log.Info().Msgf("📝 New applications (not in live): %v", newApps)
+	}
+
+	if err := deps.createFolder(cfg.OutputFolder, true); err != nil {
+		log.Error().Msgf("❌ Failed to create output folder: %s", cfg.OutputFolder)
+		return err
+	}
+
+	// Advice the user to limit the Application Selection
+	if !searchIsLimited && len(targetApps.SelectedApps) > 50 {
+		log.Warn().Msgf("💡 You are rendering %d Applications. You might want to limit the Applications rendered.", len(targetApps.SelectedApps))
+		log.Warn().Msg("💡 Check out the documentation under section `Application Selection` for more information.")
+	}
+
+	// For debugging, write manifests to files
+	if cfg.Debug {
+		targetManifest := argoapplication.ApplicationsToString(targetApps.SelectedApps)
+		if err := utils.WriteFile(fmt.Sprintf("%s/%s.yaml", tempFolder, targetBranch.FolderName()), targetManifest); err != nil {
+			log.Error().Msg("❌ Failed to write target apps")
+			return err
+		}
+	}
+
+	// Render target apps via local ArgoCD
+	deleteAfterProcessing := !cfg.CreateCluster
+	_, targetManifests, extractDuration, err := deps.renderApps(
+		localArgoCD,
+		cfg.Timeout,
+		nil, // No base apps - we'll fetch from remote
+		targetApps.SelectedApps,
+		uniqueID,
+		deleteAfterProcessing,
+	)
+	if err != nil {
+		log.Error().Msg("❌ Failed to extract resources")
+		return err
+	}
+
+	// Fetch live manifests from remote ArgoCD for matched applications
+	var matchedAppNames []string
+	for name := range matchedApps {
+		matchedAppNames = append(matchedAppNames, name)
+	}
+
+	liveManifestsRaw, err := remoteArgoCD.FetchLiveManifestsForApps(matchedAppNames)
+	if err != nil {
+		log.Error().Msg("❌ Failed to fetch live manifests from remote ArgoCD")
+		return err
+	}
+
+	// Build a lookup of target apps by name for ignoreDifferences parsing
+	targetAppByName := make(map[string]argoapplication.ArgoResource, len(targetApps.SelectedApps))
+	for _, app := range targetApps.SelectedApps {
+		targetAppByName[app.Name] = app
+	}
+
+	// Convert LiveAppManifest to ExtractedApp
+	liveManifests := make([]extract.ExtractedApp, len(liveManifestsRaw))
+	for i, lm := range liveManifestsRaw {
+		if app, ok := targetAppByName[lm.Name]; ok {
+			normalized, err := extract.NormalizeManifests(lm.Manifests, app)
+			if err != nil {
+				log.Error().Err(err).Msgf("❌ Failed to normalize live manifests for %s", lm.Name)
+				return err
+			}
+			lm.Manifests = normalized
+		} else {
+			normalized, err := extract.NormalizeManifests(lm.Manifests, argoapplication.ArgoResource{})
+			if err != nil {
+				log.Error().Err(err).Msgf("❌ Failed to normalize live manifests for %s", lm.Name)
+				return err
+			}
+			lm.Manifests = normalized
+		}
+
+		liveManifests[i] = extract.ExtractedApp{
+			Id:         lm.Name,
+			Name:       lm.Name,
+			SourcePath: "live",
+			Manifest:   lm.Manifests,
+			Branch:     git.Live,
+		}
+	}
+
+	// Convert to AppInfos
+	liveAppInfos, err := convertExtractedAppsToAppInfos(liveManifests, cfg.IgnoreResourceRules)
+	if err != nil {
+		log.Error().Msg("❌ Failed to convert live manifests to yaml")
+		return err
+	}
+	targetAppInfos, err := convertExtractedAppsToAppInfos(targetManifests, cfg.IgnoreResourceRules)
+	if err != nil {
+		log.Error().Msg("❌ Failed to convert target manifests to yaml")
+		return err
+	}
+
+	// Write manifests output
+	{
+		var liveAppCombinedYaml []string
+		var targetAppCombinedYaml []string
+		for _, app := range liveAppInfos {
+			if app.FileContent != "" {
+				liveAppCombinedYaml = append(liveAppCombinedYaml, app.FileContent)
+			}
+		}
+		for _, app := range targetAppInfos {
+			if app.FileContent != "" {
+				targetAppCombinedYaml = append(targetAppCombinedYaml, app.FileContent)
+			}
+		}
+		if err := utils.WriteFile(fmt.Sprintf("%s/%s.yaml", cfg.OutputFolder, liveBranch.FolderName()), strings.Join(liveAppCombinedYaml, "\n---\n")); err != nil {
+			log.Error().Msg("❌ Failed to write live manifests")
+			return err
+		}
+		if err := utils.WriteFile(fmt.Sprintf("%s/%s.yaml", cfg.OutputFolder, targetBranch.FolderName()), strings.Join(targetAppCombinedYaml, "\n---\n")); err != nil {
+			log.Error().Msg("❌ Failed to write target manifests")
+			return err
+		}
+	}
+
+	// Create stats info
+	statsInfo := diff.StatsInfo{
+		FullDuration:               time.Since(startTime),
+		ExtractDuration:            extractDuration + convertAppSetsToAppsDuration,
+		ArgoCDInstallationDuration: argocdInstallationDuration,
+		ClusterCreationDuration:    clusterCreationDuration,
+		ApplicationCount:           len(liveManifests) + len(targetManifests),
+	}
+
+	// Create selection info for live comparison (base = live, no skipped apps from live)
+	var skippedApplications int
+	var skippedApplicationSets int
+	for _, app := range targetApps.SkippedApps {
+		switch app.Kind {
+		case argoapplication.Application:
+			skippedApplications++
+		case argoapplication.ApplicationSet:
+			skippedApplicationSets++
+		}
+	}
+
+	selectionInfo := diff.SelectionInfo{
+		Base: diff.AppSelectionInfo{
+			SkippedApplications:    0,
+			SkippedApplicationSets: 0,
+		},
+		Target: diff.AppSelectionInfo{
+			SkippedApplications:    skippedApplications,
+			SkippedApplicationSets: skippedApplicationSets,
+		},
+	}
+
+	// Generate diff between live and target
+	if err := deps.generateDiff(
+		cfg.Title,
+		cfg.OutputFolder,
+		liveBranch,
+		targetBranch,
+		liveAppInfos,
+		targetAppInfos,
+		&cfg.DiffIgnore,
+		cfg.LineCount,
+		cfg.MaxDiffLength,
+		cfg.HideDeletedAppDiff,
+		statsInfo,
+		selectionInfo,
+	); err != nil {
+		log.Error().Msg("❌ Failed to generate diff")
+		return err
+	}
+
+	log.Info().Msgf("⏰ Run time stats: %s", statsInfo.Stats())
+
+	return nil
 }

--- a/cmd/main_live_test.go
+++ b/cmd/main_live_test.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/dag-andersen/argocd-diff-preview/pkg/app_selector"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/argoapplication"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/argocd"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/diff"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/extract"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/git"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/utils"
+)
+
+type fakeRemoteClient struct {
+	receivedMatchNames []string
+	liveManifests      []argocd.LiveAppManifest
+}
+
+func (f *fakeRemoteClient) MatchApplicationsByName(targetAppNames []string) (map[string]string, []string, error) {
+	f.receivedMatchNames = append([]string{}, targetAppNames...)
+	matches := make(map[string]string)
+	for _, name := range targetAppNames {
+		matches[name] = name
+	}
+	return matches, nil, nil
+}
+
+func (f *fakeRemoteClient) FetchLiveManifestsForApps(appNames []string) ([]argocd.LiveAppManifest, error) {
+	if f.liveManifests != nil {
+		return f.liveManifests, nil
+	}
+	var results []argocd.LiveAppManifest
+	for _, name := range appNames {
+		results = append(results, argocd.LiveAppManifest{
+			Name:      name,
+			Manifests: []unstructured.Unstructured{},
+		})
+	}
+	return results, nil
+}
+
+func TestRunLiveComparison_MatchesAfterAppSetConversion(t *testing.T) {
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	targetDir := filepath.Join(tempDir, "target-branch")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+	appYaml := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-from-file
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/phantom/infra
+    path: charts/app
+    targetRevision: main
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "app.yaml"), appYaml, 0644))
+
+	cfg := &Config{
+		CompareLive:  true,
+		TargetBranch: "feature",
+		BaseBranch:   "main",
+		Repo:         "phantom/infra",
+		OutputFolder: filepath.Join(tempDir, "output"),
+	}
+
+	convertedApp := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]any{
+				"name": "expanded-app",
+			},
+		},
+	}
+
+	fakeRemote := &fakeRemoteClient{}
+
+	deps := liveComparisonDeps{
+		listChangedFiles: func(folder1 string, folder2 string) ([]string, time.Duration, error) {
+			return nil, 0, nil
+		},
+		createFolder: func(path string, clear bool) error { return nil },
+		writeNoAppsFound: func(title string, outputFolder string, selectors []app_selector.Selector, changedFiles []string) error {
+			return nil
+		},
+		newRemoteArgoCD: func(url string, token string, insecure bool) remoteArgoCDClient { return fakeRemote },
+		newK8sClient:    func() (*utils.K8sClient, error) { return &utils.K8sClient{}, nil },
+		deleteOldApplications: func(client *utils.K8sClient, namespace string, ageInMinutes int) error {
+			return nil
+		},
+		newLocalArgoCD: func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation {
+			return &argocd.ArgoCDInstallation{}
+		},
+		installArgoCD: func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error) {
+			return 0, nil
+		},
+		loginArgoCD: func(argocd *argocd.ArgoCDInstallation) (time.Duration, error) {
+			return 0, nil
+		},
+		convertAppSets: func(argocd *argocd.ArgoCDInstallation, apps *argoapplication.ArgoSelection, branch *git.Branch, repo string, tempFolder string, redirectRevisions []string, debug bool, appSelectionOptions argoapplication.ApplicationSelectionOptions) (*argoapplication.ArgoSelection, time.Duration, error) {
+			return &argoapplication.ArgoSelection{
+				SelectedApps: []argoapplication.ArgoResource{
+					*argoapplication.NewArgoResource(&convertedApp, argoapplication.Application, "expanded-app", "expanded-app", "app.yaml", git.Target),
+				},
+				SkippedApps: []argoapplication.ArgoResource{},
+			}, 0, nil
+		},
+		renderApps: func(argocd *argocd.ArgoCDInstallation, timeout uint64, baseApps []argoapplication.ArgoResource, targetApps []argoapplication.ArgoResource, prefix string, deleteAfterProcessing bool) ([]extract.ExtractedApp, []extract.ExtractedApp, time.Duration, error) {
+			targetExtracted := extract.ExtractedApp{
+				Id:         "expanded-app",
+				Name:       "expanded-app",
+				SourcePath: "app.yaml",
+				Manifest: []unstructured.Unstructured{
+					{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "expanded-app"}}},
+				},
+				Branch: git.Target,
+			}
+			return nil, []extract.ExtractedApp{targetExtracted}, 0, nil
+		},
+		generateDiff: func(title string, outputFolder string, baseBranch *git.Branch, targetBranch *git.Branch, baseApps []diff.AppInfo, targetApps []diff.AppInfo, diffIgnoreRegex *string, lineCount uint, maxCharCount uint, hideDeletedAppDiff bool, statsInfo diff.StatsInfo, selectionInfo diff.SelectionInfo) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, runLiveComparisonWithDeps(cfg, deps))
+	assert.Equal(t, []string{"expanded-app"}, fakeRemote.receivedMatchNames)
+}
+
+func TestRunLiveComparison_AutoDetectFilesChangedUsesListChangedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	targetDir := filepath.Join(tempDir, "target-branch")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "app.yaml"), []byte("apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: test\nspec: {}\n"), 0644))
+
+	cfg := &Config{
+		CompareLive:            true,
+		TargetBranch:           "feature",
+		BaseBranch:             "main",
+		Repo:                   "phantom/infra",
+		OutputFolder:           filepath.Join(tempDir, "output"),
+		AutoDetectFilesChanged: true,
+		DryRun:                 true,
+	}
+
+	called := false
+	deps := liveComparisonDeps{
+		listChangedFiles: func(folder1 string, folder2 string) ([]string, time.Duration, error) {
+			called = true
+			return []string{"app.yaml"}, 0, nil
+		},
+		createFolder:     func(path string, clear bool) error { return nil },
+		writeNoAppsFound: func(title string, outputFolder string, selectors []app_selector.Selector, changedFiles []string) error { return nil },
+		newRemoteArgoCD:  func(url string, token string, insecure bool) remoteArgoCDClient { return &fakeRemoteClient{} },
+		newK8sClient:     func() (*utils.K8sClient, error) { return &utils.K8sClient{}, nil },
+		deleteOldApplications: func(client *utils.K8sClient, namespace string, ageInMinutes int) error {
+			return nil
+		},
+		newLocalArgoCD: func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation {
+			return &argocd.ArgoCDInstallation{}
+		},
+		installArgoCD: func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error) {
+			return 0, nil
+		},
+		loginArgoCD: func(argocd *argocd.ArgoCDInstallation) (time.Duration, error) {
+			return 0, nil
+		},
+		convertAppSets: func(argocd *argocd.ArgoCDInstallation, apps *argoapplication.ArgoSelection, branch *git.Branch, repo string, tempFolder string, redirectRevisions []string, debug bool, appSelectionOptions argoapplication.ApplicationSelectionOptions) (*argoapplication.ArgoSelection, time.Duration, error) {
+			return apps, 0, nil
+		},
+		renderApps: func(argocd *argocd.ArgoCDInstallation, timeout uint64, baseApps []argoapplication.ArgoResource, targetApps []argoapplication.ArgoResource, prefix string, deleteAfterProcessing bool) ([]extract.ExtractedApp, []extract.ExtractedApp, time.Duration, error) {
+			return nil, nil, 0, nil
+		},
+		generateDiff: func(title string, outputFolder string, baseBranch *git.Branch, targetBranch *git.Branch, baseApps []diff.AppInfo, targetApps []diff.AppInfo, diffIgnoreRegex *string, lineCount uint, maxCharCount uint, hideDeletedAppDiff bool, statsInfo diff.StatsInfo, selectionInfo diff.SelectionInfo) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, runLiveComparisonWithDeps(cfg, deps))
+	assert.True(t, called)
+}
+
+func TestRunLiveComparison_RemoteAPIIntegration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/applications":
+			_, _ = w.Write([]byte(`{"items":[{"metadata":{"name":"app1"}}]}`))
+		case "/api/v1/applications/app1/manifests":
+			_, _ = w.Write([]byte(`{"manifests":["{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"app1\"}}"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	targetDir := filepath.Join(tempDir, "target-branch")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "app.yaml"), []byte("apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: app1\nspec: {}\n"), 0644))
+
+	cfg := &Config{
+		CompareLive:  true,
+		TargetBranch: "feature",
+		BaseBranch:   "main",
+		Repo:         "phantom/infra",
+		OutputFolder: filepath.Join(tempDir, "output"),
+		LiveArgocdURL:   server.URL,
+		LiveArgocdToken: "token",
+	}
+
+	convertedApp := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]any{
+				"name": "app1",
+			},
+		},
+	}
+
+	var diffCalled bool
+	deps := liveComparisonDeps{
+		listChangedFiles: func(folder1 string, folder2 string) ([]string, time.Duration, error) {
+			return nil, 0, nil
+		},
+		createFolder:     func(path string, clear bool) error { return nil },
+		writeNoAppsFound: func(title string, outputFolder string, selectors []app_selector.Selector, changedFiles []string) error { return nil },
+		newRemoteArgoCD:  func(url string, token string, insecure bool) remoteArgoCDClient { return argocd.NewRemoteArgoCD(url, token, insecure) },
+		newK8sClient:     func() (*utils.K8sClient, error) { return &utils.K8sClient{}, nil },
+		deleteOldApplications: func(client *utils.K8sClient, namespace string, ageInMinutes int) error {
+			return nil
+		},
+		newLocalArgoCD: func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation {
+			return &argocd.ArgoCDInstallation{}
+		},
+		installArgoCD: func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error) {
+			return 0, nil
+		},
+		loginArgoCD: func(argocd *argocd.ArgoCDInstallation) (time.Duration, error) {
+			return 0, nil
+		},
+		convertAppSets: func(argocd *argocd.ArgoCDInstallation, apps *argoapplication.ArgoSelection, branch *git.Branch, repo string, tempFolder string, redirectRevisions []string, debug bool, appSelectionOptions argoapplication.ApplicationSelectionOptions) (*argoapplication.ArgoSelection, time.Duration, error) {
+			return &argoapplication.ArgoSelection{
+				SelectedApps: []argoapplication.ArgoResource{
+					*argoapplication.NewArgoResource(&convertedApp, argoapplication.Application, "app1", "app1", "app.yaml", git.Target),
+				},
+				SkippedApps: []argoapplication.ArgoResource{},
+			}, 0, nil
+		},
+		renderApps: func(argocd *argocd.ArgoCDInstallation, timeout uint64, baseApps []argoapplication.ArgoResource, targetApps []argoapplication.ArgoResource, prefix string, deleteAfterProcessing bool) ([]extract.ExtractedApp, []extract.ExtractedApp, time.Duration, error) {
+			targetExtracted := extract.ExtractedApp{
+				Id:         "app1",
+				Name:       "app1",
+				SourcePath: "app.yaml",
+				Manifest: []unstructured.Unstructured{
+					{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app1"}}},
+				},
+				Branch: git.Target,
+			}
+			return nil, []extract.ExtractedApp{targetExtracted}, 0, nil
+		},
+		generateDiff: func(title string, outputFolder string, baseBranch *git.Branch, targetBranch *git.Branch, baseApps []diff.AppInfo, targetApps []diff.AppInfo, diffIgnoreRegex *string, lineCount uint, maxCharCount uint, hideDeletedAppDiff bool, statsInfo diff.StatsInfo, selectionInfo diff.SelectionInfo) error {
+			diffCalled = true
+			assert.Equal(t, "app1", baseApps[0].Name)
+			assert.Equal(t, "app1", targetApps[0].Name)
+			return nil
+		},
+	}
+
+	require.NoError(t, runLiveComparisonWithDeps(cfg, deps))
+	assert.True(t, diffCalled)
+}
+
+func TestRunLiveComparison_SelectionInfoCountsSkippedKinds(t *testing.T) {
+	tempDir := t.TempDir()
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	targetDir := filepath.Join(tempDir, "target-branch")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "app.yaml"), []byte("apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: app1\nspec: {}\n"), 0644))
+
+	cfg := &Config{
+		CompareLive:  true,
+		TargetBranch: "feature",
+		BaseBranch:   "main",
+		Repo:         "phantom/infra",
+		OutputFolder: filepath.Join(tempDir, "output"),
+	}
+
+	convertedApp := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]any{
+				"name": "app1",
+			},
+		},
+	}
+	skippedApp := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]any{
+				"name": "skipped-app",
+			},
+		},
+	}
+	skippedAppSet := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "ApplicationSet",
+			"metadata": map[string]any{
+				"name": "skipped-appset",
+			},
+		},
+	}
+
+	deps := liveComparisonDeps{
+		listChangedFiles: func(folder1 string, folder2 string) ([]string, time.Duration, error) {
+			return nil, 0, nil
+		},
+		createFolder:     func(path string, clear bool) error { return nil },
+		writeNoAppsFound: func(title string, outputFolder string, selectors []app_selector.Selector, changedFiles []string) error { return nil },
+		newRemoteArgoCD:  func(url string, token string, insecure bool) remoteArgoCDClient { return &fakeRemoteClient{} },
+		newK8sClient:     func() (*utils.K8sClient, error) { return &utils.K8sClient{}, nil },
+		deleteOldApplications: func(client *utils.K8sClient, namespace string, ageInMinutes int) error {
+			return nil
+		},
+		newLocalArgoCD: func(client *utils.K8sClient, cfg *Config) *argocd.ArgoCDInstallation {
+			return &argocd.ArgoCDInstallation{}
+		},
+		installArgoCD: func(argocd *argocd.ArgoCDInstallation, debug bool, secretsFolder string) (time.Duration, error) {
+			return 0, nil
+		},
+		loginArgoCD: func(argocd *argocd.ArgoCDInstallation) (time.Duration, error) {
+			return 0, nil
+		},
+		convertAppSets: func(argocd *argocd.ArgoCDInstallation, apps *argoapplication.ArgoSelection, branch *git.Branch, repo string, tempFolder string, redirectRevisions []string, debug bool, appSelectionOptions argoapplication.ApplicationSelectionOptions) (*argoapplication.ArgoSelection, time.Duration, error) {
+			return &argoapplication.ArgoSelection{
+				SelectedApps: []argoapplication.ArgoResource{
+					*argoapplication.NewArgoResource(&convertedApp, argoapplication.Application, "app1", "app1", "app.yaml", git.Target),
+				},
+				SkippedApps: []argoapplication.ArgoResource{
+					*argoapplication.NewArgoResource(&skippedApp, argoapplication.Application, "skipped-app", "skipped-app", "skipped.yaml", git.Target),
+					*argoapplication.NewArgoResource(&skippedAppSet, argoapplication.ApplicationSet, "skipped-appset", "skipped-appset", "skipped-appset.yaml", git.Target),
+				},
+			}, 0, nil
+		},
+		renderApps: func(argocd *argocd.ArgoCDInstallation, timeout uint64, baseApps []argoapplication.ArgoResource, targetApps []argoapplication.ArgoResource, prefix string, deleteAfterProcessing bool) ([]extract.ExtractedApp, []extract.ExtractedApp, time.Duration, error) {
+			targetExtracted := extract.ExtractedApp{
+				Id:         "app1",
+				Name:       "app1",
+				SourcePath: "app.yaml",
+				Manifest: []unstructured.Unstructured{
+					{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app1"}}},
+				},
+				Branch: git.Target,
+			}
+			return nil, []extract.ExtractedApp{targetExtracted}, 0, nil
+		},
+		generateDiff: func(title string, outputFolder string, baseBranch *git.Branch, targetBranch *git.Branch, baseApps []diff.AppInfo, targetApps []diff.AppInfo, diffIgnoreRegex *string, lineCount uint, maxCharCount uint, hideDeletedAppDiff bool, statsInfo diff.StatsInfo, selectionInfo diff.SelectionInfo) error {
+			assert.Equal(t, 1, selectionInfo.Target.SkippedApplications)
+			assert.Equal(t, 1, selectionInfo.Target.SkippedApplicationSets)
+			return nil
+		},
+	}
+
+	require.NoError(t, runLiveComparisonWithDeps(cfg, deps))
+}

--- a/docs/options.md
+++ b/docs/options.md
@@ -19,6 +19,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 
 | Flag                                | Environment Variable              | Default | Description                                                                                                                      |
 | ----------------------------------- | --------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--compare-live`                    | `COMPARE_LIVE`                    | `false` | Compare target branch against live state from a remote Argo CD instance                                                          |
 | `--create-cluster`                  | `CREATE_CLUSTER`                  | `true`  | Create a new cluster if it doesn't exist                                                                                         |
 | `--disable-client-throttling`       | `DISABLE_CLIENT_THROTTLING`       | `false` | Disable client-side throttling (rely on API Priority and Fairness instead)                                                       |
 | `--auto-detect-files-changed`       | `AUTO_DETECT_FILES_CHANGED`       | `false` | Auto detect files changed between branches                                                                                       |
@@ -30,6 +31,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--keep-cluster-alive`              | `KEEP_CLUSTER_ALIVE`              | `false` | Keep cluster alive after the tool finishes                                                                                       |
 | `--kind-internal`                   | `KIND_INTERNAL`                   | `false` | Use the kind cluster's internal address in the kubeconfig (allows connecting to the cluster when running the CLI in a container) |
 | `--use-argocd-api`                  | `USE_ARGOCD_API`                  | `false` | Use Argo CD API instead of CLI (useful for namespace-scoped Argo CD installations)                                               |
+| `--live-argocd-insecure`            | `LIVE_ARGOCD_INSECURE`            | `false` | Skip TLS certificate verification for remote Argo CD (useful for self-signed certificates)                                       |
 | `--version`, `-v`                   | -                                 | -       | Prints version information                                                                                                       |
 
 ## Options
@@ -54,6 +56,8 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--k3d-options <options>`                 | `K3D_OPTIONS`                | -                                      | k3d options (only for k3d)                                                          |
 | `--kind-options <options>`                | `KIND_OPTIONS`               | -                                      | kind options (only for kind)                                                        |
 | `--line-count <count>`, `-c`              | `LINE_COUNT`                 | `7`                                    | Generate diffs with \<n\> lines of context                                          |
+| `--live-argocd-token <token>`             | `LIVE_ARGOCD_TOKEN`          | -                                      | API token for authenticating with the remote Argo CD instance (required for live)   |
+| `--live-argocd-url <url>`                 | `LIVE_ARGOCD_URL`            | -                                      | URL of the remote Argo CD instance (required for live)                              |
 | `--log-format <format>`                   | `LOG_FORMAT`                 | `human`                                | Log format. Options: `human`, `json`                                                |
 | `--max-diff-length <length>`              | `MAX_DIFF_LENGTH`            | `65536`                                | Max diff message character count (only limits the generated Markdown file)          |
 | `--output-folder <folder>`, `-o`          | `OUTPUT_FOLDER`              | `./output`                             | Output folder where the diff will be saved                                          |
@@ -62,3 +66,14 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--selector <selector>`, `-l`             | `SELECTOR`                   | -                                      | Label selector to filter on (e.g., `key1=value1,key2=value2`)                       |
 | `--timeout <seconds>`                     | `TIMEOUT`                    | `180`                                  | Set timeout in seconds                                                              |
 | `--title <title>`                         | `TITLE`                      | `Argo CD Diff Preview`                 | Custom title for the markdown output                                                |
+
+## Live comparison example
+
+```bash
+argocd-diff-preview \
+  --compare-live \
+  --live-argocd-url https://argocd.example.com \
+  --live-argocd-token "$ARGOCD_READ_TOKEN" \
+  --target-branch feature \
+  --repo my-org/my-repo
+```

--- a/integration-test/branch-1/target-live/output.html
+++ b/integration-test/branch-1/target-live/output.html
@@ -1,0 +1,161 @@
+<html>
+<head>
+<style>
+body {
+	font-family: arial;
+}
+.container {
+	margin: auto;
+	width: 910px;
+}
+.diffs {
+	margin: 20px 0 20px 0;
+}
+.diff_container {
+	width: 910px;
+	overflow-x: scroll;
+	border-radius: 8px;
+	background:rgb(239, 239, 239);
+	scrollbar-width: none;
+	margin: 10px 0 10px 0;
+}
+table {
+	font-family: monospace;
+	border-spacing: 0px;
+	width: 100%;
+}
+tr.normal_line {
+	background:rgb(239, 239, 239);
+}
+tr.added_line {
+	background:rgb(169, 216, 184);
+}
+tr.removed_line {
+	background:rgb(247, 149, 173);
+}
+tr.comment_line {
+	background:rgb(197, 194, 194);
+}
+pre {
+	margin: 0;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Argo CD Diff Preview</h1>
+
+<p>Summary:</p>
+<pre>Total: 1 files changed
+
+Modified (1):
+± my-app (+3|-22)</pre>
+
+<div class="diffs">
+<details>
+<summary>
+my-app (live -&gt; examples/helm/applications/my-app.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: my-app (live -&gt; examples/helm/applications/my-app.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>     helm.sh/chart: myApp-0.1.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: super-app-name</pre></td></tr>
+	<tr class="added_line"><td><pre>+  namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   replicas: 1</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="comment_line"><td><pre>@@ skipped 17 lines (21 -&gt; 37) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>         readinessProbe:</pre></td></tr>
+	<tr class="normal_line"><td><pre>           httpGet:</pre></td></tr>
+	<tr class="normal_line"><td><pre>             path: /</pre></td></tr>
+	<tr class="normal_line"><td><pre>             port: http</pre></td></tr>
+	<tr class="normal_line"><td><pre>         resources: {}</pre></td></tr>
+	<tr class="normal_line"><td><pre>         securityContext: {}</pre></td></tr>
+	<tr class="normal_line"><td><pre>       securityContext: {}</pre></td></tr>
+	<tr class="normal_line"><td><pre>       serviceAccountName: super-app-name</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: v1</pre></td></tr>
+	<tr class="removed_line"><td><pre>-kind: Pod</pre></td></tr>
+	<tr class="removed_line"><td><pre>-metadata:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  annotations:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    helm.sh/hook: test</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  labels:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    app.kubernetes.io/managed-by: Helm</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    app.kubernetes.io/version: 1.16.0</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    helm.sh/chart: myApp-0.1.0</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  name: super-app-name-test-connection</pre></td></tr>
+	<tr class="removed_line"><td><pre>-spec:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  containers:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  - args:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    - super-app-name:80</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    command:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    - wget</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    image: busybox</pre></td></tr>
+	<tr class="removed_line"><td><pre>-    name: wget</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  restartPolicy: Never</pre></td></tr>
+	<tr class="removed_line"><td><pre>----</pre></td></tr>
+	<tr class="removed_line"><td><pre>-apiVersion: v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Service</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>     helm.sh/chart: myApp-0.1.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: super-app-name</pre></td></tr>
+	<tr class="added_line"><td><pre>+  namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   ports:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   - name: http</pre></td></tr>
+	<tr class="normal_line"><td><pre>     port: 80</pre></td></tr>
+	<tr class="normal_line"><td><pre>     protocol: TCP</pre></td></tr>
+	<tr class="normal_line"><td><pre>     targetPort: http</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="normal_line"><td><pre>   type: ClusterIP</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> automountServiceAccountToken: true</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: ServiceAccount</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>     helm.sh/chart: myApp-0.1.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: super-app-name</pre></td></tr>
+	<tr class="added_line"><td><pre>+  namespace: default</pre></td></tr>
+</table>
+</div>
+</details>
+</div>
+
+<pre>_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+</div>
+</body>
+</html>

--- a/integration-test/branch-1/target-live/output.md
+++ b/integration-test/branch-1/target-live/output.md
@@ -1,0 +1,109 @@
+## Argo CD Diff Preview
+
+Summary:
+```yaml
+Total: 1 files changed
+
+Modified (1):
+± my-app (+3|-22)
+```
+
+<details>
+<summary>my-app (live -> examples/helm/applications/my-app.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: my-app (live -> examples/helm/applications/my-app.yaml) @@
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   labels:
+     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: myApp
+     app.kubernetes.io/version: 1.16.0
+     helm.sh/chart: myApp-0.1.0
+   name: super-app-name
++  namespace: default
+ spec:
+   replicas: 1
+   selector:
+     matchLabels:
+       app.kubernetes.io/instance: my-app
+       app.kubernetes.io/name: myApp
+   template:
+     metadata:
+       labels:
+         app.kubernetes.io/instance: my-app
+@@ skipped 17 lines (21 -> 37) @@
+         readinessProbe:
+           httpGet:
+             path: /
+             port: http
+         resources: {}
+         securityContext: {}
+       securityContext: {}
+       serviceAccountName: super-app-name
+ ---
+ apiVersion: v1
+-kind: Pod
+-metadata:
+-  annotations:
+-    helm.sh/hook: test
+-  labels:
+-    app.kubernetes.io/instance: my-app
+-    app.kubernetes.io/managed-by: Helm
+-    app.kubernetes.io/name: myApp
+-    app.kubernetes.io/version: 1.16.0
+-    helm.sh/chart: myApp-0.1.0
+-  name: super-app-name-test-connection
+-spec:
+-  containers:
+-  - args:
+-    - super-app-name:80
+-    command:
+-    - wget
+-    image: busybox
+-    name: wget
+-  restartPolicy: Never
+----
+-apiVersion: v1
+ kind: Service
+ metadata:
+   labels:
+     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: myApp
+     app.kubernetes.io/version: 1.16.0
+     helm.sh/chart: myApp-0.1.0
+   name: super-app-name
++  namespace: default
+ spec:
+   ports:
+   - name: http
+     port: 80
+     protocol: TCP
+     targetPort: http
+   selector:
+     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/name: myApp
+   type: ClusterIP
+ ---
+ apiVersion: v1
+ automountServiceAccountToken: true
+ kind: ServiceAccount
+ metadata:
+   labels:
+     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: myApp
+     app.kubernetes.io/version: 1.16.0
+     helm.sh/chart: myApp-0.1.0
+   name: super-app-name
++  namespace: default
+```
+
+</details>
+
+_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/makefile
+++ b/makefile
@@ -90,7 +90,7 @@ run-unit-tests:
 # go test -coverprofile=coverage.out ./...
 # go tool cover -html=coverage.out
 
-# New Go-based integration tests
+# New Go-based integration tests (live test spins up Kind cluster with ArgoCD)
 run-integration-tests-go: go-build
 	cd integration-test && go test -v -timeout 60m -run TestIntegration ./...
 

--- a/pkg/argoapplication/application_sets.go
+++ b/pkg/argoapplication/application_sets.go
@@ -14,6 +14,43 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// ConvertAppSetsToAppsInBranch converts ApplicationSets to Applications for a single branch
+func ConvertAppSetsToAppsInBranch(
+	argocd *argocd.ArgoCDInstallation,
+	apps *ArgoSelection,
+	branch *git.Branch,
+	repo string,
+	tempFolder string,
+	redirectRevisions []string,
+	debug bool,
+	appSelectionOptions ApplicationSelectionOptions,
+) (*ArgoSelection, time.Duration, error) {
+	startTime := time.Now()
+
+	log.Info().Str("branch", branch.Name).Msg("🤖 Converting ApplicationSets to Applications")
+
+	branchTempFolder := fmt.Sprintf("%s/%s", tempFolder, branch.Type())
+	resultApps, err := processAppSets(
+		argocd,
+		apps,
+		branch,
+		branchTempFolder,
+		debug,
+		appSelectionOptions,
+		repo,
+		redirectRevisions,
+	)
+
+	if err != nil {
+		log.Error().Str("branch", branch.Name).Msg("❌ Failed to generate apps")
+		return nil, time.Since(startTime), err
+	}
+
+	log.Debug().Msgf("🤖 Converted ApplicationSets to Applications in %s", time.Since(startTime).Round(time.Second))
+
+	return resultApps, time.Since(startTime), nil
+}
+
 func ConvertAppSetsToAppsInBothBranches(
 	argocd *argocd.ArgoCDInstallation,
 	baseApps *ArgoSelection,

--- a/pkg/argoapplication/applications.go
+++ b/pkg/argoapplication/applications.go
@@ -68,6 +68,17 @@ func (a *ArgoResource) WriteToFolder(folder string) (string, error) {
 	return randomFileName, nil
 }
 
+// GetApplicationsForBranch gets applications for a single branch (public wrapper)
+func GetApplicationsForBranch(
+	argocdNamespace string,
+	branch *git.Branch,
+	appSelectionOptions ApplicationSelectionOptions,
+	repo string,
+	redirectRevisions []string,
+) (*ArgoSelection, error) {
+	return getApplications(argocdNamespace, branch, appSelectionOptions, repo, redirectRevisions)
+}
+
 // GetApplicationsForBranches gets applications for both base and target branches
 func GetApplicationsForBranches(
 	argocdNamespace string,

--- a/pkg/argocd/remote.go
+++ b/pkg/argocd/remote.go
@@ -1,0 +1,251 @@
+package argocd
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// RemoteArgoCD represents a connection to a remote ArgoCD instance
+type RemoteArgoCD struct {
+	URL        string
+	Token      string
+	HTTPClient *http.Client
+}
+
+// NewRemoteArgoCD creates a new RemoteArgoCD client
+func NewRemoteArgoCD(url, token string, insecure bool) *RemoteArgoCD {
+	// Normalize URL - remove trailing slash
+	url = strings.TrimSuffix(url, "/")
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	// Skip TLS verification if insecure mode is enabled
+	if insecure {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // User explicitly requested insecure mode
+		}
+		log.Debug().Msg("TLS certificate verification disabled for remote ArgoCD")
+	}
+
+	return &RemoteArgoCD{
+		URL:        url,
+		Token:      token,
+		HTTPClient: client,
+	}
+}
+
+// ApplicationListResponse represents the response from /api/v1/applications
+type ApplicationListResponse struct {
+	Items []ApplicationItem `json:"items"`
+}
+
+// ApplicationItem represents a single application in the list response
+type ApplicationItem struct {
+	Metadata ApplicationMetadata `json:"metadata"`
+	Spec     ApplicationSpec     `json:"spec"`
+}
+
+// ApplicationMetadata contains application metadata
+type ApplicationMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// ApplicationSpec contains application spec
+type ApplicationSpec struct {
+	Source      *ApplicationSource   `json:"source,omitempty"`
+	Sources     []ApplicationSource  `json:"sources,omitempty"`
+	Destination ApplicationDestination `json:"destination"`
+}
+
+// ApplicationSource contains source information
+type ApplicationSource struct {
+	RepoURL        string `json:"repoURL"`
+	Path           string `json:"path"`
+	TargetRevision string `json:"targetRevision"`
+}
+
+// ApplicationDestination contains destination information
+type ApplicationDestination struct {
+	Server    string `json:"server"`
+	Namespace string `json:"namespace"`
+}
+
+// ManifestsResponse represents the response from /api/v1/applications/{app}/manifests
+type ManifestsResponse struct {
+	Manifests []string `json:"manifests"`
+}
+
+// doRequest performs an authenticated HTTP request to the ArgoCD API
+func (r *RemoteArgoCD) doRequest(method, path string) ([]byte, error) {
+	url := fmt.Sprintf("%s%s", r.URL, path)
+
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.Token))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// ListApplications returns all applications from the remote ArgoCD instance
+func (r *RemoteArgoCD) ListApplications() ([]ApplicationItem, error) {
+	log.Debug().Msgf("Listing applications from remote ArgoCD: %s", r.URL)
+
+	body, err := r.doRequest("GET", "/api/v1/applications")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list applications: %w", err)
+	}
+
+	var response ApplicationListResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse applications response: %w", err)
+	}
+
+	log.Debug().Msgf("Found %d applications in remote ArgoCD", len(response.Items))
+	return response.Items, nil
+}
+
+// FetchManifests retrieves the rendered manifests for an application
+func (r *RemoteArgoCD) FetchManifests(appName string) ([]unstructured.Unstructured, error) {
+	log.Debug().Msgf("Fetching manifests for application: %s", appName)
+
+	path := fmt.Sprintf("/api/v1/applications/%s/manifests", appName)
+	body, err := r.doRequest("GET", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch manifests for %s: %w", appName, err)
+	}
+
+	var response ManifestsResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse manifests response: %w", err)
+	}
+
+	var manifests []unstructured.Unstructured
+	for _, manifestStr := range response.Manifests {
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(manifestStr), &obj.Object); err != nil {
+			// Try JSON unmarshal as fallback
+			if err := json.Unmarshal([]byte(manifestStr), &obj.Object); err != nil {
+				log.Warn().Err(err).Msgf("Failed to parse manifest for %s, skipping", appName)
+				continue
+			}
+		}
+		manifests = append(manifests, obj)
+	}
+
+	log.Debug().Msgf("Fetched %d manifests for application: %s", len(manifests), appName)
+	return manifests, nil
+}
+
+// LiveAppManifest represents fetched manifests for a live application
+type LiveAppManifest struct {
+	Name      string
+	Manifests []unstructured.Unstructured
+}
+
+// FetchLiveManifestsForApps fetches manifests for multiple applications by name
+func (r *RemoteArgoCD) FetchLiveManifestsForApps(appNames []string) ([]LiveAppManifest, error) {
+	log.Info().Msgf("🌐 Fetching live manifests from remote ArgoCD for %d applications", len(appNames))
+
+	var results []LiveAppManifest
+	var fetchErrors []string
+
+	for _, appName := range appNames {
+		manifests, err := r.FetchManifests(appName)
+		if err != nil {
+			log.Warn().Err(err).Msgf("Failed to fetch manifests for %s", appName)
+			fetchErrors = append(fetchErrors, appName)
+			continue
+		}
+
+		results = append(results, LiveAppManifest{
+			Name:      appName,
+			Manifests: manifests,
+		})
+	}
+
+	if len(fetchErrors) > 0 {
+		log.Warn().Msgf("⚠️ Failed to fetch manifests for %d applications: %v", len(fetchErrors), fetchErrors)
+	}
+
+	log.Info().Msgf("🌐 Successfully fetched live manifests for %d applications", len(results))
+	return results, nil
+}
+
+// GetApplicationByName returns a specific application by name
+func (r *RemoteArgoCD) GetApplicationByName(appName string) (*ApplicationItem, error) {
+	log.Debug().Msgf("Getting application by name: %s", appName)
+
+	path := fmt.Sprintf("/api/v1/applications/%s", appName)
+	body, err := r.doRequest("GET", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application %s: %w", appName, err)
+	}
+
+	var app ApplicationItem
+	if err := json.Unmarshal(body, &app); err != nil {
+		return nil, fmt.Errorf("failed to parse application response: %w", err)
+	}
+
+	return &app, nil
+}
+
+// MatchApplicationsByName matches target applications to live applications by exact name
+// Returns a map of target app name -> live app name for apps that exist in both
+func (r *RemoteArgoCD) MatchApplicationsByName(targetAppNames []string) (map[string]string, []string, error) {
+	liveApps, err := r.ListApplications()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list live applications: %w", err)
+	}
+
+	// Build a set of live app names
+	liveAppSet := make(map[string]bool)
+	for _, app := range liveApps {
+		liveAppSet[app.Metadata.Name] = true
+	}
+
+	// Match target apps to live apps
+	matches := make(map[string]string)
+	var newApps []string
+
+	for _, targetName := range targetAppNames {
+		if liveAppSet[targetName] {
+			matches[targetName] = targetName
+		} else {
+			newApps = append(newApps, targetName)
+		}
+	}
+
+	log.Info().Msgf("🔗 Matched %d applications to live state, %d new applications", len(matches), len(newApps))
+	return matches, newApps, nil
+}

--- a/pkg/argocd/remote_test.go
+++ b/pkg/argocd/remote_test.go
@@ -1,0 +1,231 @@
+package argocd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRemoteArgoCD(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		token    string
+		wantURL  string
+	}{
+		{
+			name:    "URL without trailing slash",
+			url:     "https://argocd.example.com",
+			token:   "test-token",
+			wantURL: "https://argocd.example.com",
+		},
+		{
+			name:    "URL with trailing slash",
+			url:     "https://argocd.example.com/",
+			token:   "test-token",
+			wantURL: "https://argocd.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewRemoteArgoCD(tt.url, tt.token, false)
+			assert.Equal(t, tt.wantURL, client.URL)
+			assert.Equal(t, tt.token, client.Token)
+			assert.NotNil(t, client.HTTPClient)
+		})
+	}
+}
+
+func TestRemoteArgoCD_ListApplications(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request
+		assert.Equal(t, "/api/v1/applications", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Return mock response
+		response := ApplicationListResponse{
+			Items: []ApplicationItem{
+				{
+					Metadata: ApplicationMetadata{
+						Name:      "app1",
+						Namespace: "argocd",
+					},
+					Spec: ApplicationSpec{
+						Destination: ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "default",
+						},
+					},
+				},
+				{
+					Metadata: ApplicationMetadata{
+						Name:      "app2",
+						Namespace: "argocd",
+					},
+					Spec: ApplicationSpec{
+						Destination: ApplicationDestination{
+							Server:    "https://kubernetes.default.svc",
+							Namespace: "production",
+						},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+	apps, err := client.ListApplications()
+
+	require.NoError(t, err)
+	assert.Len(t, apps, 2)
+	assert.Equal(t, "app1", apps[0].Metadata.Name)
+	assert.Equal(t, "app2", apps[1].Metadata.Name)
+}
+
+func TestRemoteArgoCD_FetchManifests(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request
+		assert.Equal(t, "/api/v1/applications/test-app/manifests", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		// Return mock response with JSON manifests
+		response := ManifestsResponse{
+			Manifests: []string{
+				`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"test-deployment"}}`,
+				`{"apiVersion":"v1","kind":"Service","metadata":{"name":"test-service"}}`,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+	manifests, err := client.FetchManifests("test-app")
+
+	require.NoError(t, err)
+	assert.Len(t, manifests, 2)
+	assert.Equal(t, "Deployment", manifests[0].GetKind())
+	assert.Equal(t, "test-deployment", manifests[0].GetName())
+	assert.Equal(t, "Service", manifests[1].GetKind())
+	assert.Equal(t, "test-service", manifests[1].GetName())
+}
+
+func TestRemoteArgoCD_FetchManifests_Error(t *testing.T) {
+	// Create a mock server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"application not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+	_, err := client.FetchManifests("nonexistent-app")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestRemoteArgoCD_MatchApplicationsByName(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := ApplicationListResponse{
+			Items: []ApplicationItem{
+				{Metadata: ApplicationMetadata{Name: "app1"}},
+				{Metadata: ApplicationMetadata{Name: "app2"}},
+				{Metadata: ApplicationMetadata{Name: "app3"}},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+
+	targetApps := []string{"app1", "app2", "new-app"}
+	matches, newApps, err := client.MatchApplicationsByName(targetApps)
+
+	require.NoError(t, err)
+
+	// Should match app1 and app2
+	assert.Len(t, matches, 2)
+	assert.Equal(t, "app1", matches["app1"])
+	assert.Equal(t, "app2", matches["app2"])
+
+	// new-app should be identified as new
+	assert.Len(t, newApps, 1)
+	assert.Equal(t, "new-app", newApps[0])
+}
+
+func TestRemoteArgoCD_FetchLiveManifestsForApps(t *testing.T) {
+	callCount := 0
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// Return different manifests based on the app name
+		response := ManifestsResponse{
+			Manifests: []string{
+				`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm-` + r.URL.Path + `"}}`,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+	results, err := client.FetchLiveManifestsForApps([]string{"app1", "app2"})
+
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, 2, callCount)
+
+	// Verify the results contain the expected app names
+	appNames := make([]string, len(results))
+	for i, r := range results {
+		appNames[i] = r.Name
+	}
+	assert.Contains(t, appNames, "app1")
+	assert.Contains(t, appNames, "app2")
+}
+
+func TestRemoteArgoCD_GetApplicationByName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/applications/test-app", r.URL.Path)
+
+		app := ApplicationItem{
+			Metadata: ApplicationMetadata{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: ApplicationSpec{
+				Source: &ApplicationSource{
+					RepoURL:        "https://github.com/example/repo",
+					Path:           "manifests",
+					TargetRevision: "main",
+				},
+				Destination: ApplicationDestination{
+					Server:    "https://kubernetes.default.svc",
+					Namespace: "default",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(app)
+	}))
+	defer server.Close()
+
+	client := NewRemoteArgoCD(server.URL, "test-token", false)
+	app, err := client.GetApplicationByName("test-app")
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-app", app.Metadata.Name)
+	assert.Equal(t, "https://github.com/example/repo", app.Spec.Source.RepoURL)
+}

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -444,6 +444,22 @@ func labelApplicationWithRunID(a *argoapplication.ArgoResource, runID string) er
 	return nil
 }
 
+// NormalizeManifests applies ignoreDifferences and removes ArgoCD tracking IDs
+func NormalizeManifests(manifests []unstructured.Unstructured, app argoapplication.ArgoResource) ([]unstructured.Unstructured, error) {
+	if app.Yaml != nil {
+		rules := parseIgnoreDifferencesFromApp(app)
+		if len(rules) > 0 {
+			applyIgnoreDifferencesToManifests(manifests, rules)
+		}
+	}
+
+	if err := removeArgoCDTrackingID(manifests); err != nil {
+		return nil, err
+	}
+
+	return manifests, nil
+}
+
 // removeArgoCDTrackingID removes the "argocd.argoproj.io/tracking-id" annotation from the application
 func removeArgoCDTrackingID(a []unstructured.Unstructured) error {
 	for _, obj := range a {

--- a/pkg/extract/normalize_test.go
+++ b/pkg/extract/normalize_test.go
@@ -1,0 +1,96 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/dag-andersen/argocd-diff-preview/pkg/argoapplication"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/git"
+)
+
+func TestNormalizeManifests_RemovesTrackingIDAndIgnoresFields(t *testing.T) {
+	appYaml := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]any{
+				"name": "app1",
+			},
+			"spec": map[string]any{
+				"ignoreDifferences": []any{
+					map[string]any{
+						"group":        "",
+						"kind":         "ConfigMap",
+						"jsonPointers": []any{"/data/ignored"},
+					},
+				},
+			},
+		},
+	}
+
+	app := argoapplication.ArgoResource{
+		Yaml:   appYaml,
+		Kind:   argoapplication.Application,
+		Id:     "app1",
+		Name:   "app1",
+		Branch: git.Target,
+	}
+
+	manifest := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name": "app1",
+				"annotations": map[string]any{
+					"argocd.argoproj.io/tracking-id": "tracking",
+				},
+			},
+			"data": map[string]any{
+				"ignored": "remove-me",
+				"keep":    "ok",
+			},
+		},
+	}
+
+	normalized, err := NormalizeManifests([]unstructured.Unstructured{manifest}, app)
+	require.NoError(t, err)
+	require.Len(t, normalized, 1)
+
+	annotations := normalized[0].GetAnnotations()
+	_, trackingExists := annotations["argocd.argoproj.io/tracking-id"]
+	assert.False(t, trackingExists)
+
+	data, found, err := unstructured.NestedMap(normalized[0].Object, "data")
+	require.NoError(t, err)
+	require.True(t, found)
+	_, ignoredExists := data["ignored"]
+	assert.False(t, ignoredExists)
+	assert.Equal(t, "ok", data["keep"])
+}
+
+func TestNormalizeManifests_NoAppYamlStillRemovesTracking(t *testing.T) {
+	manifest := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name": "app1",
+				"annotations": map[string]any{
+					"argocd.argoproj.io/tracking-id": "tracking",
+				},
+			},
+		},
+	}
+
+	normalized, err := NormalizeManifests([]unstructured.Unstructured{manifest}, argoapplication.ArgoResource{})
+	require.NoError(t, err)
+	require.Len(t, normalized, 1)
+
+	annotations := normalized[0].GetAnnotations()
+	_, trackingExists := annotations["argocd.argoproj.io/tracking-id"]
+	assert.False(t, trackingExists)
+}

--- a/pkg/git/branch.go
+++ b/pkg/git/branch.go
@@ -17,6 +17,8 @@ const (
 	Base BranchType = "base"
 	// Target represents the target branch for comparison
 	Target BranchType = "target"
+	// Live represents live state from a remote ArgoCD instance
+	Live BranchType = "live"
 )
 
 func (b BranchType) ShortName() string {


### PR DESCRIPTION
Adds a new comparison mode that diffs PR changes against live deployed state from a remote ArgoCD instance, rather than comparing against a base branch.

- New CLI flags: `--compare-live`, `--live-argocd-url`, `--live-argocd-token`, `--live-argocd-insecure`
- Fetches live manifests via ArgoCD REST API (`/api/v1/applications/{app}/manifests`)
- Matches PR applications to live applications by name
- Applies ignoreDifferences from application spec and removes ArgoCD tracking annotations for clean diffs
- Integration tests spin up a real Kind cluster with ArgoCD to validate the feature