### PR TITLE
Fix | Include namespace in manifest sort order to prevent spurious diffs (#324)

### DIFF
--- a/pkg/extract/extracted_app.go
+++ b/pkg/extract/extracted_app.go
@@ -59,13 +59,15 @@ func (e *ExtractedApp) FlattenToString(ignoreResourceRules []resource_filter.Ign
 }
 
 func (e *ExtractedApp) sortManifests() {
-	// Sort by API version, then by kind, then by name, with CRDs always at the end
+	// Sort by API version, then by kind, then by namespace, then by name, with CRDs always at the end
 
 	sort.SliceStable(e.Manifests, func(i, j int) bool {
 		apiI := e.Manifests[i].GetAPIVersion()
 		apiJ := e.Manifests[j].GetAPIVersion()
 		kindI := e.Manifests[i].GetKind()
 		kindJ := e.Manifests[j].GetKind()
+		nsI := e.Manifests[i].GetNamespace()
+		nsJ := e.Manifests[j].GetNamespace()
 		nameI := e.Manifests[i].GetName()
 		nameJ := e.Manifests[j].GetName()
 
@@ -78,12 +80,15 @@ func (e *ExtractedApp) sortManifests() {
 			return !isCRD_I
 		}
 
-		// Sort by apiVersion first, then by kind, then by name
+		// Sort by apiVersion first, then by kind, then by namespace, then by name
 		if apiI != apiJ {
 			return apiI < apiJ
 		}
 		if kindI != kindJ {
 			return kindI < kindJ
+		}
+		if nsI != nsJ {
+			return nsI < nsJ
 		}
 		return nameI < nameJ
 	})


### PR DESCRIPTION
## Summary
- Fixes non-deterministic diff output when an Application contains multiple resources with the same name but different namespaces
- Adds namespace to the manifest sort criteria in `sortManifests()` function

## Problem
When rendering Applications that create resources with identical names in different namespaces (e.g., argo-workflows creates `RoleBinding` named `app1-argo-workflows-workflow` in both `argocd` and `default` namespaces), the diff output showed spurious namespace changes:

```diff
   name: app1-argo-workflows-workflow
-  namespace: argocd
+  namespace: default
...
   name: app1-argo-workflows-workflow
-  namespace: default
+  namespace: argocd
```

This happened because the sort order was non-deterministic for resources with the same `apiVersion/kind/name` but different namespaces.

## Solution
Updated `sortManifests()` in `pkg/extract/extracted_app.go` to include namespace in the sort criteria:

- **Before:** `apiVersion → kind → name`
- **After:** `apiVersion → kind → namespace → name`

## Testing
- Reproduced the bug with argo-workflows helm chart (creates RoleBindings in multiple namespaces)
- Before fix: 2/3 runs showed spurious namespace changes
- After fix: 5/5 runs showed consistent, correct diffs
- All unit tests pass
- Linter passes (0 issues)

Fixes #324