### PR TITLE
Feat | Add `--concurrency` flag to control parallel application processing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -307,6 +307,7 @@ func run(cfg *Config) error {
 	baseManifests, targetManifests, extractDuration, err := extract.RenderApplicationsFromBothBranches(
 		argocd,
 		cfg.Timeout,
+		cfg.Concurrency,
 		baseApps.SelectedApps,
 		targetApps.SelectedApps,
 		uniqueID,

--- a/docs/options.md
+++ b/docs/options.md
@@ -49,6 +49,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--base-branch <branch>`, `-b`            | `BASE_BRANCH`                | `main`                                 | Base branch name                                                                            |
 | `--cluster <tool>`                        | `CLUSTER`                    | `auto`                                 | Local cluster tool. Options: `kind`, `minikube`, `k3d`, `auto`                              |
 | `--cluster-name <name>`                   | `CLUSTER_NAME`               | `argocd-diff-preview`                  | Cluster name (only for kind & k3d)                                                          |
+| `--concurrency <count>`                   | `CONCURRENCY`                | `40`                                   | Max concurrent application processing (0 = unlimited, not recommended)                      |
 | `--diff-ignore <pattern>`, `-i`           | `DIFF_IGNORE`                | -                                      | Ignore lines in diff. Example: `v[1,9]+.[1,9]+.[1,9]+` for ignoring version changes         |
 | `--file-regex <regex>`, `-r`              | `FILE_REGEX`                 | -                                      | Regex to filter files. Example: `/apps_.*\.yaml`                                            |
 | `--files-changed <files>`                 | `FILES_CHANGED`              | -                                      | List of files changed between branches (comma, space or newline separated)                  |


### PR DESCRIPTION
## Summary
- Adds a new `--concurrency` flag to control the maximum number of applications processed concurrently
- Default is 40 (same as previous hardcoded value)
- Setting to 0 allows unlimited concurrency (not recommended)

## Changes
- **cmd/options.go**: Add `--concurrency` flag with default value of 40, environment variable `CONCURRENCY`
- **pkg/extract/extract.go**: Replace hardcoded `const maxWorkers = 40` with configurable parameter
- **cmd/main.go**: Pass concurrency config to `RenderApplicationsFromBothBranches()`
- **docs/options.md**: Document the new option

## Usage
```bash
# Use default (40 concurrent)
argocd-diff-preview --repo owner/repo --target-branch feature

# Limit to 10 concurrent applications
argocd-diff-preview --repo owner/repo --target-branch feature --concurrency 10

# Unlimited (not recommended)
argocd-diff-preview --repo owner/repo --target-branch feature --concurrency 0

# Or via environment variable:
CONCURRENCY=10 argocd-diff-preview --repo owner/repo --target-branch feature
```