### PR TITLE
Test | Optimize integration test ordering and add branch-15 test

### DIFF
--- a/integration-test/branch-15/target/output.html
+++ b/integration-test/branch-15/target/output.html
@@ -1,0 +1,123 @@
+<html>
+<head>
+<style>
+body {
+	font-family: arial;
+}
+.container {
+	margin: auto;
+	width: 910px;
+}
+.diffs {
+	margin: 20px 0 20px 0;
+}
+.diff_container {
+	width: 910px;
+	overflow-x: scroll;
+	border-radius: 8px;
+	background:rgb(239, 239, 239);
+	scrollbar-width: none;
+	margin: 10px 0 10px 0;
+}
+table {
+	font-family: monospace;
+	border-spacing: 0px;
+	width: 100%;
+}
+tr.normal_line {
+	background:rgb(239, 239, 239);
+}
+tr.added_line {
+	background:rgb(169, 216, 184);
+}
+tr.removed_line {
+	background:rgb(247, 149, 173);
+}
+tr.comment_line {
+	background:rgb(197, 194, 194);
+}
+pre {
+	margin: 0;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Argo CD Diff Preview</h1>
+
+<p>Summary:</p>
+<pre>Total: 1 files changed
+
+Modified (1):
+± order-change-example (+8|-7)</pre>
+
+<div class="diffs">
+<details>
+<summary>
+order-change-example (examples/order-change/app/app-set.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: order-change-example (examples/order-change/app/app-set.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  name: order-change-example-deploy-1</pre></td></tr>
+	<tr class="added_line"><td><pre>+  name: order-change-example-deploy-2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   replicas: 2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-      app: example-deploy-1</pre></td></tr>
+	<tr class="added_line"><td><pre>+      app: example-deploy-2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        app: example-deploy-1</pre></td></tr>
+	<tr class="added_line"><td><pre>+        app: example-deploy-2</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: dag-andersen/myapp:latest</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: myapp</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         - containerPort: 80</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="removed_line"><td><pre>-kind: Deployment</pre></td></tr>
+	<tr class="added_line"><td><pre>+kind: StatefulSet</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  name: order-change-example-deploy-2</pre></td></tr>
+	<tr class="added_line"><td><pre>+  name: order-change-example-sfs-1</pre></td></tr>
+	<tr class="normal_line"><td><pre>   namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   replicas: 2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-      app: example-deploy-2</pre></td></tr>
+	<tr class="added_line"><td><pre>+      app: example-sfs-1</pre></td></tr>
+	<tr class="added_line"><td><pre>+  serviceName: order-change-example-sfs-1</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        app: example-deploy-2</pre></td></tr>
+	<tr class="added_line"><td><pre>+        app: example-sfs-1</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: dag-andersen/myapp:latest</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: myapp</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         - containerPort: 80</pre></td></tr>
+</table>
+</div>
+</details>
+</div>
+
+<pre>_Stats_:
+[Applications: 46], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+</div>
+</body>
+</html>

--- a/integration-test/branch-15/target/output.md
+++ b/integration-test/branch-15/target/output.md
@@ -1,0 +1,71 @@
+## Argo CD Diff Preview
+
+Summary:
+```yaml
+Total: 1 files changed
+
+Modified (1):
+± order-change-example (+8|-7)
+```
+
+<details>
+<summary>order-change-example (examples/order-change/app/app-set.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: order-change-example (examples/order-change/app/app-set.yaml) @@
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+-  name: order-change-example-deploy-1
++  name: order-change-example-deploy-2
+   namespace: default
+ spec:
+   replicas: 2
+   selector:
+     matchLabels:
+-      app: example-deploy-1
++      app: example-deploy-2
+   template:
+     metadata:
+       labels:
+-        app: example-deploy-1
++        app: example-deploy-2
+     spec:
+       containers:
+       - image: dag-andersen/myapp:latest
+         name: myapp
+         ports:
+         - containerPort: 80
+ ---
+ apiVersion: apps/v1
+-kind: Deployment
++kind: StatefulSet
+ metadata:
+-  name: order-change-example-deploy-2
++  name: order-change-example-sfs-1
+   namespace: default
+ spec:
+   replicas: 2
+   selector:
+     matchLabels:
+-      app: example-deploy-2
++      app: example-sfs-1
++  serviceName: order-change-example-sfs-1
+   template:
+     metadata:
+       labels:
+-        app: example-deploy-2
++        app: example-sfs-1
+     spec:
+       containers:
+       - image: dag-andersen/myapp:latest
+         name: myapp
+         ports:
+         - containerPort: 80
+```
+
+</details>
+
+_Stats_:
+[Applications: 46], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -182,11 +182,10 @@ var testCases = []TestCase{
 		BaseBranch:   "integration-test/branch-6/base",
 	},
 	{
-		Name:          "branch-7/target",
-		TargetBranch:  "integration-test/branch-7/target",
-		BaseBranch:    "integration-test/branch-7/base",
-		FilesChanged:  "examples/helm/values/filtered.yaml",
-		CreateCluster: "true",
+		Name:         "branch-7/target",
+		TargetBranch: "integration-test/branch-7/target",
+		BaseBranch:   "integration-test/branch-7/base",
+		FilesChanged: "examples/helm/values/filtered.yaml",
 	},
 	{
 		Name:         "branch-8/target",
@@ -253,6 +252,11 @@ var testCases = []TestCase{
 		BaseBranch:   "integration-test/branch-13/base",
 		Suffix:       "-2",
 		Selector:     "team=your-team",
+	},
+	{
+		Name:         "branch-15/target",
+		TargetBranch: "integration-test/branch-15/target",
+		BaseBranch:   "integration-test/branch-15/base",
 	},
 	// This test verifies that disabling cluster roles without using the API fails.
 	// When createClusterRoles: false is set but --use-argocd-api is not used,
@@ -330,17 +334,10 @@ func TestIntegration(t *testing.T) {
 		}
 	})
 
-	// Create a copy of testCases to shuffle
-	shuffledCases := make([]TestCase, len(testCases))
-	copy(shuffledCases, testCases)
+	// Order tests to minimize cluster recreations
+	shuffledCases := orderTestCases(testCases)
 
-	// Shuffle using time-based seed
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	rng.Shuffle(len(shuffledCases), func(i, j int) {
-		shuffledCases[i], shuffledCases[j] = shuffledCases[j], shuffledCases[i]
-	})
-
-	t.Logf("Running %d tests in randomized order", len(shuffledCases))
+	t.Logf("Running %d tests in optimized order", len(shuffledCases))
 
 	// Track how many tests since last cluster creation
 	testsSinceClusterCreation := 0
@@ -426,6 +423,55 @@ func printToTTY(msg string) {
 		_, _ = tty.WriteString(msg)
 		_ = tty.Close()
 	}
+}
+
+// orderTestCases groups and shuffles test cases to minimize cluster recreations.
+// Tests are partitioned by RBAC configuration (roles-enabled vs roles-disabled),
+// shuffled within each group, and then concatenated. Tests that explicitly require
+// CreateCluster are placed at the front of each group so they overlap with the
+// cluster creation that already happens at group boundaries.
+func orderTestCases(cases []TestCase) []TestCase {
+	var rolesEnabled, rolesDisabled []TestCase
+	for _, tc := range cases {
+		needsRolesDisabled := tc.DisableClusterRoles == "true" || tc.UseArgocdApi == "true" || (tc.UseArgocdApi != "false" && *useArgocdApi)
+		if needsRolesDisabled {
+			rolesDisabled = append(rolesDisabled, tc)
+		} else {
+			rolesEnabled = append(rolesEnabled, tc)
+		}
+	}
+
+	// Shuffle each group independently
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rng.Shuffle(len(rolesEnabled), func(i, j int) {
+		rolesEnabled[i], rolesEnabled[j] = rolesEnabled[j], rolesEnabled[i]
+	})
+	rng.Shuffle(len(rolesDisabled), func(i, j int) {
+		rolesDisabled[i], rolesDisabled[j] = rolesDisabled[j], rolesDisabled[i]
+	})
+
+	// Move CreateCluster tests to the front of each group
+	sortCreateClusterFirst := func(group []TestCase) {
+		slices.SortStableFunc(group, func(a, b TestCase) int {
+			aCreate := a.CreateCluster == "true"
+			bCreate := b.CreateCluster == "true"
+			if aCreate && !bCreate {
+				return -1
+			}
+			if !aCreate && bCreate {
+				return 1
+			}
+			return 0
+		})
+	}
+	sortCreateClusterFirst(rolesEnabled)
+	sortCreateClusterFirst(rolesDisabled)
+
+	// Concatenate: roles-enabled first, then roles-disabled
+	result := make([]TestCase, 0, len(cases))
+	result = append(result, rolesEnabled...)
+	result = append(result, rolesDisabled...)
+	return result
 }
 
 // deleteKindCluster deletes the kind cluster used for testing


### PR DESCRIPTION
## Summary
- Group integration tests by RBAC configuration to minimize cluster recreations (~4-5 instead of ~8-10)
- Add integration test for branch-15 (deployment → statefulset conversion)
- Remove unnecessary `CreateCluster` from branch-7 test