### PR TITLE
Feat | Rename `--argocd-config` flag to `--argocd-config-dir`

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -117,7 +117,7 @@ type RawOptions struct {
 	ArgocdChartRepoPassword    string `mapstructure:"argocd-chart-repo-password"`
 	ArgocdLoginOptions         string `mapstructure:"argocd-login-options"`
 	ArgocdAuthToken            string `mapstructure:"argocd-auth-token"`
-	ArgocdConfigPath           string `mapstructure:"argocd-config"`
+	ArgocdConfigPath           string `mapstructure:"argocd-config-dir"`
 	UseArgoCDApi               bool   `mapstructure:"use-argocd-api"`
 	RenderMethod               string `mapstructure:"render-method"`
 	RedirectTargetRevisions    string `mapstructure:"redirect-target-revisions"`
@@ -262,7 +262,7 @@ func Parse() *Config {
 	viper.SetDefault("ignore-resources", DefaultIgnoreResourceRules)
 	viper.SetDefault("disable-client-throttling", DefaultDisableClientThrottling)
 	viper.SetDefault("concurrency", DefaultConcurrency)
-	viper.SetDefault("argocd-config", DefaultArgocdConfigPath)
+	viper.SetDefault("argocd-config-dir", DefaultArgocdConfigPath)
 
 	// Basic flags
 	rootCmd.Flags().BoolP("debug", "d", false, "Activate debug mode")
@@ -285,7 +285,7 @@ func Parse() *Config {
 	rootCmd.Flags().String("argocd-chart-repo-password", DefaultArgocdChartRepoPassword, "Argo CD Helm Repo Password")
 	rootCmd.Flags().String("argocd-auth-token", DefaultArgocdAuthToken, "Argo CD Auth Token for API access")
 	rootCmd.Flags().String("argocd-login-options", DefaultArgocdLoginOptions, "Additional options to pass to 'argocd login' command")
-	rootCmd.Flags().String("argocd-config", DefaultArgocdConfigPath, "Path to the Argo CD config folder (contains values.yaml for Helm chart customization)")
+	rootCmd.Flags().String("argocd-config-dir", DefaultArgocdConfigPath, "Path to the Argo CD config folder (contains values.yaml for Helm chart customization)")
 	// Git related
 	rootCmd.Flags().StringP("base-branch", "b", DefaultBaseBranch, "Base branch name")
 	rootCmd.Flags().StringP("target-branch", "t", "", "Target branch name (required)")
@@ -634,7 +634,7 @@ func (o *Config) LogConfig() {
 	log.Info().Msgf("✨ - output-folder: %s", o.OutputFolder)
 	log.Info().Msgf("✨ - argocd-namespace: %s", o.ArgocdNamespace)
 	if o.ArgocdConfigPath != DefaultArgocdConfigPath {
-		log.Info().Msgf("✨ - argocd-config: %s", o.ArgocdConfigPath)
+		log.Info().Msgf("✨ - argocd-config-dir: %s", o.ArgocdConfigPath)
 	}
 	log.Info().Msgf("✨ - repo: %s", o.Repo)
 	log.Info().Msgf("✨ - timeout: %d seconds", o.Timeout)

--- a/docs/options.md
+++ b/docs/options.md
@@ -45,6 +45,7 @@ argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-bran
 | `--argocd-auth-token <token>`             | `ARGOCD_AUTH_TOKEN`          | -                                      | Argo CD authentication token (skips default admin login)                                    |
 | `--argocd-namespace <namespace>`          | `ARGOCD_NAMESPACE`           | `argocd`                               | Namespace to use for Argo CD                                                                |
 | `--argocd-ui-url <url>`                   | `ARGOCD_UI_URL`              | -                                      | Argo CD URL to generate application links in diff output (e.g., https://argocd.example.com) |
+| `--argocd-config-dir <path>`              | `ARGOCD_CONFIG_DIR`          | `./argocd-config`                      | Path to the Argo CD config folder (contains values.yaml for Helm chart customization)       |
 |                                           |
 | `--base-branch <branch>`, `-b`            | `BASE_BRANCH`                | `main`                                 | Base branch name                                                                            |
 | `--cluster <tool>`                        | `CLUSTER`                    | `auto`                                 | Local cluster tool. Options: `kind`, `minikube`, `k3d`, `auto`                              |

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -940,10 +940,10 @@ func buildArgs(tc TestCase, createCluster bool) []string {
 	}
 
 	// When the test requires cluster roles to be disabled (API mode or DisableClusterRoles flag),
-	// pass --argocd-config pointing at the no-cluster-roles directory (createClusterRoles: false).
+	// pass --argocd-config-dir pointing at the no-cluster-roles directory (createClusterRoles: false).
 	// This avoids mutating the shared argocd-config/values.yaml on disk.
 	if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
-		args = append(args, "--argocd-config", "./integration-test/no-cluster-roles")
+		args = append(args, "--argocd-config-dir", "./integration-test/no-cluster-roles")
 	}
 
 	return args


### PR DESCRIPTION
## Summary

- Rename `--argocd-config` CLI flag to `--argocd-config-dir` for clarity
- Add the option to `docs/options.md`