### PR TITLE
Fix | Update invalid-token test path and rebase integration test outputs

### DIFF
--- a/integration-test/branch-1/target-1/output.html
+++ b/integration-test/branch-1/target-1/output.html
@@ -48,12 +48,13 @@ pre {
 <h1>Argo CD Diff Preview</h1>
 
 <p>Summary:</p>
-<pre>Total: 2 files changed
+<pre>Total: 3 files changed
 
 Deleted (1):
 - folder2 (-19)
 
-Modified (1):
+Modified (2):
+± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)</pre>
 
 <div class="diffs">
@@ -90,12 +91,41 @@ folder2 (examples/git-generator/app/app-set.yaml)
 
 <details>
 <summary>
-nginx-ingress (examples/helm/applications/nginx.yaml)
+multi-source-app (examples/multi-source/app.yaml)
 </summary>
 <div class="diff_container">
 <table>
 	
-	<tr class="comment_line"><td><pre>@@ Application modified: nginx-ingress (examples/helm/applications/nginx.yaml) @@</pre></td></tr>
+	<tr class="comment_line"><td><pre>@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: my-org/backend:1.0.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        - containerPort: 8080</pre></td></tr>
+	<tr class="added_line"><td><pre>+        - containerPort: 80</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="comment_line"><td><pre>@@ skipped 11 lines (24 -&gt; 34) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-      - image: nginx:1.25</pre></td></tr>
+	<tr class="added_line"><td><pre>+      - image: nginx:1.26</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         - containerPort: 80</pre></td></tr>
+</table>
+</div>
+</details>
+
+<details>
+<summary>
+nginx-ingress (examples/external-chart/nginx.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: nginx-ingress (examples/external-chart/nginx.yaml) @@</pre></td></tr>
 	<tr class="normal_line"><td><pre>               fieldPath: metadata.namespace</pre></td></tr>
 	<tr class="normal_line"><td><pre>         - name: LD_PRELOAD</pre></td></tr>
 	<tr class="normal_line"><td><pre>           value: /usr/local/lib/libmimalloc.so</pre></td></tr>
@@ -110,7 +140,7 @@ nginx-ingress (examples/helm/applications/nginx.yaml)
 </div>
 
 <pre>_Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-1/target-1/output.md
+++ b/integration-test/branch-1/target-1/output.md
@@ -2,12 +2,13 @@
 
 Summary:
 ```yaml
-Total: 2 files changed
+Total: 3 files changed
 
 Deleted (1):
 - folder2 (-19)
 
-Modified (1):
+Modified (2):
+± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)
 ```
 
@@ -41,11 +42,38 @@ Modified (1):
 </details>
 
 <details>
-<summary>nginx-ingress (examples/helm/applications/nginx.yaml)</summary>
+<summary>multi-source-app (examples/multi-source/app.yaml)</summary>
 <br>
 
 ```diff
-@@ Application modified: nginx-ingress (examples/helm/applications/nginx.yaml) @@
+@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@
+       - image: my-org/backend:1.0.0
+         name: backend
+         ports:
+-        - containerPort: 8080
++        - containerPort: 80
+ ---
+ apiVersion: apps/v1
+ kind: Deployment
+@@ skipped 11 lines (24 -> 34) @@
+         app: frontend
+     spec:
+       containers:
+-      - image: nginx:1.25
++      - image: nginx:1.26
+         name: frontend
+         ports:
+         - containerPort: 80
+```
+
+</details>
+
+<details>
+<summary>nginx-ingress (examples/external-chart/nginx.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: nginx-ingress (examples/external-chart/nginx.yaml) @@
                fieldPath: metadata.namespace
          - name: LD_PRELOAD
            value: /usr/local/lib/libmimalloc.so
@@ -59,4 +87,4 @@ Modified (1):
 </details>
 
 _Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/branch-1/target-2/output.html
+++ b/integration-test/branch-1/target-2/output.html
@@ -48,10 +48,13 @@ pre {
 <h1>Argo CD Diff Preview</h1>
 
 <p>Summary:</p>
-<pre>Total: 1 files changed
+<pre>Total: 2 files changed
 
 Deleted (1):
-- folder2 (-19)</pre>
+- folder2 (-19)
+
+Modified (1):
+± multi-source-app (+1|-1)</pre>
 
 <div class="diffs">
 <details>
@@ -84,10 +87,44 @@ folder2 (examples/git-generator/app/app-set.yaml)
 </table>
 </div>
 </details>
+
+<details>
+<summary>
+multi-source-app (examples/multi-source/app.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: my-org/backend:1.0.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        - containerPort: 8080</pre></td></tr>
+	<tr class="added_line"><td><pre>+        - containerPort: 80</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>   namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   replicas: 2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+</table>
+</div>
+</details>
 </div>
 
 <pre>_Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-1/target-2/output.md
+++ b/integration-test/branch-1/target-2/output.md
@@ -2,10 +2,13 @@
 
 Summary:
 ```yaml
-Total: 1 files changed
+Total: 2 files changed
 
 Deleted (1):
 - folder2 (-19)
+
+Modified (1):
+± multi-source-app (+1|-1)
 ```
 
 <details>
@@ -37,5 +40,37 @@ Deleted (1):
 
 </details>
 
+<details>
+<summary>multi-source-app (examples/multi-source/app.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@
+       app: backend
+   template:
+     metadata:
+       labels:
+         app: backend
+     spec:
+       containers:
+       - image: my-org/backend:1.0.0
+         name: backend
+         ports:
+-        - containerPort: 8080
++        - containerPort: 80
+ ---
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: frontend
+   namespace: default
+ spec:
+   replicas: 2
+   selector:
+     matchLabels:
+```
+
+</details>
+
 _Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/branch-1/target-3/output.html
+++ b/integration-test/branch-1/target-3/output.html
@@ -48,12 +48,13 @@ pre {
 <h1>Argo CD Diff Preview</h1>
 
 <p>Summary:</p>
-<pre>Total: 2 files changed
+<pre>Total: 3 files changed
 
 Deleted (1):
 - folder2
 
-Modified (1):
+Modified (2):
+± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)</pre>
 
 <div class="diffs">
@@ -72,12 +73,58 @@ folder2 [<a href="https://argocd.example.com/applications/folder2">link</a>] (ex
 
 <details>
 <summary>
-nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/helm/applications/nginx.yaml)
+multi-source-app [<a href="https://argocd.example.com/applications/multi-source-app">link</a>] (examples/multi-source/app.yaml)
 </summary>
 <div class="diff_container">
 <table>
 	
-	<tr class="comment_line"><td><pre>@@ Application modified: nginx-ingress (examples/helm/applications/nginx.yaml) @@</pre></td></tr>
+	<tr class="comment_line"><td><pre>@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: my-org/backend:1.0.0</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: backend</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        - containerPort: 8080</pre></td></tr>
+	<tr class="added_line"><td><pre>+        - containerPort: 80</pre></td></tr>
+	<tr class="normal_line"><td><pre> ---</pre></td></tr>
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>   namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   replicas: 2</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-      - image: nginx:1.25</pre></td></tr>
+	<tr class="added_line"><td><pre>+      - image: nginx:1.26</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: frontend</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         - containerPort: 80</pre></td></tr>
+</table>
+</div>
+</details>
+
+<details>
+<summary>
+nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/external-chart/nginx.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: nginx-ingress (examples/external-chart/nginx.yaml) @@</pre></td></tr>
 	<tr class="normal_line"><td><pre>         - name: POD_NAME</pre></td></tr>
 	<tr class="normal_line"><td><pre>           valueFrom:</pre></td></tr>
 	<tr class="normal_line"><td><pre>             fieldRef:</pre></td></tr>
@@ -106,7 +153,7 @@ nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">l
 </div>
 
 <pre>_Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-1/target-3/output.md
+++ b/integration-test/branch-1/target-3/output.md
@@ -2,12 +2,13 @@
 
 Summary:
 ```yaml
-Total: 2 files changed
+Total: 3 files changed
 
 Deleted (1):
 - folder2
 
-Modified (1):
+Modified (2):
+± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)
 ```
 
@@ -23,11 +24,55 @@ Diff content omitted because '--hide-deleted-app-diff' is enabled.
 </details>
 
 <details>
-<summary>nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/helm/applications/nginx.yaml)</summary>
+<summary>multi-source-app [<a href="https://argocd.example.com/applications/multi-source-app">link</a>] (examples/multi-source/app.yaml)</summary>
 <br>
 
 ```diff
-@@ Application modified: nginx-ingress (examples/helm/applications/nginx.yaml) @@
+@@ Application modified: multi-source-app (examples/multi-source/app.yaml) @@
+       app: backend
+   template:
+     metadata:
+       labels:
+         app: backend
+     spec:
+       containers:
+       - image: my-org/backend:1.0.0
+         name: backend
+         ports:
+-        - containerPort: 8080
++        - containerPort: 80
+ ---
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: frontend
+   namespace: default
+ spec:
+   replicas: 2
+   selector:
+     matchLabels:
+       app: frontend
+   template:
+     metadata:
+       labels:
+         app: frontend
+     spec:
+       containers:
+-      - image: nginx:1.25
++      - image: nginx:1.26
+         name: frontend
+         ports:
+         - containerPort: 80
+```
+
+</details>
+
+<details>
+<summary>nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/external-chart/nginx.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: nginx-ingress (examples/external-chart/nginx.yaml) @@
          - name: POD_NAME
            valueFrom:
              fieldRef:
@@ -55,4 +100,4 @@ Diff content omitted because '--hide-deleted-app-diff' is enabled.
 </details>
 
 _Stats_:
-[Applications: 25], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 47], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/branch-2/target/output.html
+++ b/integration-test/branch-2/target/output.html
@@ -51,22 +51,22 @@ pre {
 <pre>Total: 1 files changed
 
 Modified (1):
-± my-app (+5|-5)</pre>
+± internal-chart-example (+5|-5)</pre>
 
 <div class="diffs">
 <details>
 <summary>
-my-app (examples/helm/applications/my-app.yaml)
+internal-chart-example (examples/internal-chart/app.yaml)
 </summary>
 <div class="diff_container">
 <table>
 	
-	<tr class="comment_line"><td><pre>@@ Application modified: my-app (examples/helm/applications/my-app.yaml) @@</pre></td></tr>
+	<tr class="comment_line"><td><pre>@@ Application modified: internal-chart-example (examples/internal-chart/app.yaml) @@</pre></td></tr>
 	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
 	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
 	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
 	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
-	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
@@ -79,12 +79,12 @@ my-app (examples/helm/applications/my-app.yaml)
 	<tr class="added_line"><td><pre>+  replicas: 5</pre></td></tr>
 	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
 	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
-	<tr class="normal_line"><td><pre>       app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>       app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
 	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
 	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
-	<tr class="normal_line"><td><pre>         app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>         app.kubernetes.io/managed-by: Helm</pre></td></tr>
 	<tr class="normal_line"><td><pre>         app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="comment_line"><td><pre>@@ skipped 12 lines (25 -&gt; 36) @@</pre></td></tr>
@@ -105,7 +105,7 @@ my-app (examples/helm/applications/my-app.yaml)
 	<tr class="normal_line"><td><pre> kind: Service</pre></td></tr>
 	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
 	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
-	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
@@ -120,7 +120,7 @@ my-app (examples/helm/applications/my-app.yaml)
 	<tr class="normal_line"><td><pre>     protocol: TCP</pre></td></tr>
 	<tr class="normal_line"><td><pre>     targetPort: http</pre></td></tr>
 	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
-	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="normal_line"><td><pre>   type: ClusterIP</pre></td></tr>
 	<tr class="normal_line"><td><pre> ---</pre></td></tr>
@@ -129,7 +129,7 @@ my-app (examples/helm/applications/my-app.yaml)
 	<tr class="normal_line"><td><pre> kind: ServiceAccount</pre></td></tr>
 	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
 	<tr class="normal_line"><td><pre>   labels:</pre></td></tr>
-	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>     app.kubernetes.io/instance: internal-chart-example</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/managed-by: Helm</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/name: myApp</pre></td></tr>
 	<tr class="normal_line"><td><pre>     app.kubernetes.io/version: 1.16.0</pre></td></tr>
@@ -143,7 +143,7 @@ my-app (examples/helm/applications/my-app.yaml)
 </div>
 
 <pre>_Stats_:
-[Applications: 24], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 46], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-2/target/output.md
+++ b/integration-test/branch-2/target/output.md
@@ -5,20 +5,20 @@ Summary:
 Total: 1 files changed
 
 Modified (1):
-± my-app (+5|-5)
+± internal-chart-example (+5|-5)
 ```
 
 <details>
-<summary>my-app (examples/helm/applications/my-app.yaml)</summary>
+<summary>internal-chart-example (examples/internal-chart/app.yaml)</summary>
 <br>
 
 ```diff
-@@ Application modified: my-app (examples/helm/applications/my-app.yaml) @@
+@@ Application modified: internal-chart-example (examples/internal-chart/app.yaml) @@
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    labels:
-     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/instance: internal-chart-example
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: myApp
      app.kubernetes.io/version: 1.16.0
@@ -31,12 +31,12 @@ Modified (1):
 +  replicas: 5
    selector:
      matchLabels:
-       app.kubernetes.io/instance: my-app
+       app.kubernetes.io/instance: internal-chart-example
        app.kubernetes.io/name: myApp
    template:
      metadata:
        labels:
-         app.kubernetes.io/instance: my-app
+         app.kubernetes.io/instance: internal-chart-example
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/name: myApp
 @@ skipped 12 lines (25 -> 36) @@
@@ -57,7 +57,7 @@ Modified (1):
  kind: Service
  metadata:
    labels:
-     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/instance: internal-chart-example
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: myApp
      app.kubernetes.io/version: 1.16.0
@@ -72,7 +72,7 @@ Modified (1):
      protocol: TCP
      targetPort: http
    selector:
-     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/instance: internal-chart-example
      app.kubernetes.io/name: myApp
    type: ClusterIP
  ---
@@ -81,7 +81,7 @@ Modified (1):
  kind: ServiceAccount
  metadata:
    labels:
-     app.kubernetes.io/instance: my-app
+     app.kubernetes.io/instance: internal-chart-example
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: myApp
      app.kubernetes.io/version: 1.16.0
@@ -94,4 +94,4 @@ Modified (1):
 </details>
 
 _Stats_:
-[Applications: 24], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 46], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -284,7 +284,7 @@ var testCases = []TestCase{
 		BaseBranch:      "integration-test/branch-1/base",
 		Suffix:          "-invalid-token",
 		ArgocdAuthToken: "abc",
-		FilesChanged:    "examples/helm/applications/nginx.yaml",
+		FilesChanged:    "examples/external-chart/nginx.yaml",
 		ExpectFailure:   true,
 	},
 }


### PR DESCRIPTION
## Summary

- Fix `branch-1/target-invalid-token` test: the `FilesChanged` path `examples/helm/applications/nginx.yaml` was stale (file was moved to `examples/external-chart/nginx.yaml` in a previous refactor), causing 0 apps to be selected and the tool to exit cleanly instead of failing on the invalid token
- Update expected integration test outputs for branch-1 and branch-2 after rebasing their branches onto main