### PR TITLE
Feat | repo-server-api option does no longer suffix apps with -1,-2,-3

### DIFF
--- a/pkg/argoapplication/unique.go
+++ b/pkg/argoapplication/unique.go
@@ -44,10 +44,7 @@ func UniqueIds(apps []ArgoResource, branch *git.Branch) []ArgoResource {
 				// Create a copy of the app
 				newApp := app
 				newApp.Id = newId
-
-				// Update the name in the YAML
-				newApp.Yaml.SetName(newId)
-				log.Debug().Str("branch", branch.Name).Str(newApp.Kind.ShortName(), newApp.GetLongName()).Msgf("Updated name in yaml to: %s", newId)
+				log.Debug().Str("branch", branch.Name).Str(newApp.Kind.ShortName(), newApp.GetLongName()).Msgf("Updated Application ID to: %s", newId)
 
 				newApps = append(newApps, newApp)
 			}

--- a/pkg/argoapplication/unique_test.go
+++ b/pkg/argoapplication/unique_test.go
@@ -98,10 +98,6 @@ func TestUniqueNames(t *testing.T) {
 			// Check each app
 			for i := range got {
 				assert.Equal(t, tt.want[i].Id, got[i].Id, "App %d: Expected name %s, got %s", i, tt.want[i].Id, got[i].Id)
-
-				// Check YAML name matches
-				gotName := got[i].Yaml.GetName()
-				assert.Equal(t, got[i].Id, gotName, "App %d: YAML name %s doesn't match struct name %s", i, gotName, got[i].Id)
 			}
 
 			// Check uniqueness

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -237,9 +237,9 @@ func getResourcesFromApp(
 	// Store ID (kubernetes resource name) before we add a prefix and hash
 	uniqueIdBeforeModifications := app.Id
 
-	err := addApplicationPrefix(&app, prefix)
+	err := updateYamlName(&app, prefix)
 	if err != nil {
-		return ExtractedApp{}, "", fmt.Errorf("failed to prefix application name with prefix: %w", err)
+		return ExtractedApp{}, "", fmt.Errorf("failed to prefix application name with '%s': %w", prefix, err)
 	}
 
 	// After patching the application name, we can get the k8s resource name

--- a/pkg/extract/prefix.go
+++ b/pkg/extract/prefix.go
@@ -8,8 +8,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// addApplicationPrefix prefixes the application name with the branch name and a unique ID
-func addApplicationPrefix(a *argoapplication.ArgoResource, prefix string) error {
+// updateYamlName prefixes the application name with the branch name and a unique ID
+// The ID may also contain a -1, -2 suffix. This will also be added to the k8s yaml name.
+func updateYamlName(a *argoapplication.ArgoResource, prefix string) error {
 	if a.Branch == "" {
 		log.Warn().Str(a.Kind.ShortName(), a.GetLongName()).Msg("⚠️ Can't prefix application name with prefix because branch is empty")
 		return nil

--- a/pkg/extract/prefix_test.go
+++ b/pkg/extract/prefix_test.go
@@ -89,7 +89,7 @@ func TestAddApplicationPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			originalYamlName := tt.app.Yaml.GetName()
 
-			err := addApplicationPrefix(tt.app, tt.prefix)
+			err := updateYamlName(tt.app, tt.prefix)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -141,7 +141,7 @@ func TestBranchShortNames(t *testing.T) {
 			app := createTestArgoResource("test-app", "test-app", "test.yaml", tt.branch)
 			prefix := "pr123"
 
-			err := addApplicationPrefix(app, prefix)
+			err := updateYamlName(app, prefix)
 			assert.NoError(t, err)
 
 			expectedPrefix := prefix + "-" + tt.expectedShortName + "-"


### PR DESCRIPTION
Helps to avoid issues with plugins and app names

Related to: https://github.com/dag-andersen/argocd-diff-preview/issues/355#issuecomment-3979576825