### PR TITLE
Test | Add integration test for branch-16 with CMP plugin and repo-server-api

### DIFF
--- a/integration-test/branch-16/target/output.html
+++ b/integration-test/branch-16/target/output.html
@@ -1,0 +1,86 @@
+<html>
+<head>
+<style>
+body {
+	font-family: arial;
+}
+.container {
+	margin: auto;
+	width: 910px;
+}
+.diffs {
+	margin: 20px 0 20px 0;
+}
+.diff_container {
+	width: 910px;
+	overflow-x: scroll;
+	border-radius: 8px;
+	background:rgb(239, 239, 239);
+	scrollbar-width: none;
+	margin: 10px 0 10px 0;
+}
+table {
+	font-family: monospace;
+	border-spacing: 0px;
+	width: 100%;
+}
+tr.normal_line {
+	background:rgb(239, 239, 239);
+}
+tr.added_line {
+	background:rgb(169, 216, 184);
+}
+tr.removed_line {
+	background:rgb(247, 149, 173);
+}
+tr.comment_line {
+	background:rgb(197, 194, 194);
+}
+pre {
+	margin: 0;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Argo CD Diff Preview</h1>
+
+<p>Summary:</p>
+<pre>Total: 1 files changed
+
+Modified (1):
+± my-app (+1|-1)</pre>
+
+<div class="diffs">
+<details>
+<summary>
+my-app (examples/helm-kustomize-postrender/application.yaml)
+</summary>
+<div class="diff_container">
+<table>
+	
+	<tr class="comment_line"><td><pre>@@ Application modified: my-app (examples/helm-kustomize-postrender/application.yaml) @@</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: my-app</pre></td></tr>
+	<tr class="normal_line"><td><pre>         foo: bar</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       - image: nginx:1.25</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: app</pre></td></tr>
+	<tr class="normal_line"><td><pre>         ports:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-        - containerPort: 80</pre></td></tr>
+	<tr class="added_line"><td><pre>+        - containerPort: 8080</pre></td></tr>
+</table>
+</div>
+</details>
+</div>
+
+<pre>_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+</div>
+</body>
+</html>

--- a/integration-test/branch-16/target/output.md
+++ b/integration-test/branch-16/target/output.md
@@ -1,0 +1,34 @@
+## Argo CD Diff Preview
+
+Summary:
+```yaml
+Total: 1 files changed
+
+Modified (1):
+± my-app (+1|-1)
+```
+
+<details>
+<summary>my-app (examples/helm-kustomize-postrender/application.yaml)</summary>
+<br>
+
+```diff
+@@ Application modified: my-app (examples/helm-kustomize-postrender/application.yaml) @@
+   template:
+     metadata:
+       labels:
+         app: my-app
+         foo: bar
+     spec:
+       containers:
+       - image: nginx:1.25
+         name: app
+         ports:
+-        - containerPort: 80
++        - containerPort: 8080
+```
+
+</details>
+
+_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -61,6 +61,7 @@ type TestCase struct {
 	ArgocdAuthToken            string // Auth token for Argo CD (if set, will be used instead of login)
 	RenderMethod               string // "cli", "server-api", "repo-server-api", or "" to use global flag
 	DisableClusterRoles        string // Use no-cluster-roles/values.yaml (sets createClusterRoles: false)
+	ArgocdConfigDir            string // Custom argocd-config directory (relative to integration-test/); overrides auto-derived path
 	ArgocdUIURL                string // Argo CD URL for generating application links in diff output
 	ExpectFailure              bool   // If true, the test is expected to fail
 }
@@ -257,6 +258,15 @@ var testCases = []TestCase{
 		Name:         "branch-15/target",
 		TargetBranch: "integration-test/branch-15/target",
 		BaseBranch:   "integration-test/branch-15/base",
+	},
+	{
+		Name:                   "branch-16/target",
+		TargetBranch:           "integration-test/branch-16/target",
+		BaseBranch:             "integration-test/branch-16/base",
+		AutoDetectFilesChanged: "true",
+		RenderMethod:           "repo-server-api",
+		ArgocdConfigDir:        "plugin-test",
+		CreateCluster:          "true",
 	},
 	// This test verifies that disabling cluster roles without using the API fails.
 	// When createClusterRoles: false is set but --render-method=cli is used,
@@ -772,9 +782,12 @@ func runWithDocker(tc TestCase, createCluster bool) error {
 		"-v", fmt.Sprintf("%s/kind-config:/kind-config", repoRoot),
 	}
 
-	// When using API mode or DisableClusterRoles is set, mount only the values.yaml file
+	// When using a custom ArgoCD config directory, mount the entire directory.
+	// Otherwise, when using API mode or DisableClusterRoles is set, mount only the values.yaml file
 	// (which sets createClusterRoles: false) into the default argocd-config path in the container.
-	if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
+	if tc.ArgocdConfigDir != "" {
+		args = append(args, "-v", fmt.Sprintf("%s/integration-test/%s:/argocd-config", repoRoot, tc.ArgocdConfigDir))
+	} else if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
 		args = append(args, "-v", fmt.Sprintf("%s/integration-test/no-cluster-roles/values.yaml:/argocd-config/values.yaml", repoRoot))
 	}
 
@@ -941,8 +954,11 @@ func buildArgs(tc TestCase, createCluster bool) []string {
 
 	// When the test requires cluster roles to be disabled (API mode or DisableClusterRoles flag),
 	// pass --argocd-config-dir pointing at the no-cluster-roles directory (createClusterRoles: false).
+	// If ArgocdConfigDir is explicitly set, use that directory instead.
 	// This avoids mutating the shared argocd-config/values.yaml on disk.
-	if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
+	if tc.ArgocdConfigDir != "" {
+		args = append(args, "--argocd-config-dir", fmt.Sprintf("./integration-test/%s", tc.ArgocdConfigDir))
+	} else if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
 		args = append(args, "--argocd-config-dir", "./integration-test/no-cluster-roles")
 	}
 

--- a/integration-test/plugin-test/values.yaml
+++ b/integration-test/plugin-test/values.yaml
@@ -1,0 +1,30 @@
+configs:
+  cmp:
+    create: true
+    plugins:
+      kustomize-build-with-helm-oci:
+        init:
+          command: ["sh", "-c"]
+          args: ["helm dependency build"]
+        generate:
+          command: ["sh", "-c"]
+          args:
+            [
+              "helm template . -f values.yaml --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE --include-crds --api-versions monitoring.coreos.com/v1 > all.yaml && kustomize build",
+            ]
+repoServer:
+  extraContainers:
+    - name: kustomize-build-with-helm-oci
+      command:
+        - argocd-cmp-server
+      image: '{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}'
+      volumeMounts:
+        - name: plugins
+          mountPath: /home/argocd/cmp-server/plugins
+        - name: cmp-kustomize-build-with-helm
+          mountPath: /home/argocd/cmp-server/config/plugin.yaml
+          subPath: kustomize-build-with-helm-oci.yaml
+  volumes:
+    - name: cmp-kustomize-build-with-helm
+      configMap:
+        name: argocd-cmp-cm


### PR DESCRIPTION
## Summary

- Add branch-16 integration test that uses `repo-server-api` render method with auto-detect files changed
- Add `ArgocdConfigDir` field to `TestCase` struct for custom ArgoCD Helm values (e.g. CMP plugin config)
- Add `plugin-test/values.yaml` with CMP sidecar configuration for kustomize-build-with-helm-oci

Integration test matches the setup described in: https://github.com/dag-andersen/argocd-diff-preview/issues/355