### PR TITLE
chore: added charset tag

### DIFF
--- a/integration-test/branch-1/target-1/output.html
+++ b/integration-test/branch-1/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-1/target-2/output.html
+++ b/integration-test/branch-1/target-2/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-1/target-3/output.html
+++ b/integration-test/branch-1/target-3/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-10/target-1/output.html
+++ b/integration-test/branch-10/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-11/target-1/output.html
+++ b/integration-test/branch-11/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-12/target-1/output.html
+++ b/integration-test/branch-12/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-12/target-2/output.html
+++ b/integration-test/branch-12/target-2/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-13/target-1/output.html
+++ b/integration-test/branch-13/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-13/target-2/output.html
+++ b/integration-test/branch-13/target-2/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-15/target/output.html
+++ b/integration-test/branch-15/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-16/target/output.html
+++ b/integration-test/branch-16/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-2/target/output.html
+++ b/integration-test/branch-2/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-3/target/output.html
+++ b/integration-test/branch-3/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-4/target/output.html
+++ b/integration-test/branch-4/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-1/output.html
+++ b/integration-test/branch-5/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-2/output.html
+++ b/integration-test/branch-5/target-2/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-4/output.html
+++ b/integration-test/branch-5/target-4/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-6/output.html
+++ b/integration-test/branch-5/target-6/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-8/output.html
+++ b/integration-test/branch-5/target-8/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-5/target-9/output.html
+++ b/integration-test/branch-5/target-9/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-6/target/output.html
+++ b/integration-test/branch-6/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-7/target/output.html
+++ b/integration-test/branch-7/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-8/target/output.html
+++ b/integration-test/branch-8/target/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-9/target-1/output.html
+++ b/integration-test/branch-9/target-1/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/integration-test/branch-9/target-2/output.html
+++ b/integration-test/branch-9/target-2/output.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -17,6 +17,7 @@ type HTMLOutput struct {
 const htmlTemplate = `
 <html>
 <head>
+<meta charset="utf-8">
 <style>
 body {
 	font-family: arial;


### PR DESCRIPTION
# Summary
Added the charset attribute to the HTML tag to prevent garbled text from occurring with multibyte character (e.g. Japanese)  strings.

<img width="1838" height="1358" alt="image" src="https://github.com/user-attachments/assets/066a1a2f-d6a6-4c33-83c0-8eec4d1e1b25" />
