### PR TITLE
Feat | Change resource header format to Kind: namespace/name

### DIFF
--- a/integration-test/branch-1/target-1/output.html
+++ b/integration-test/branch-1/target-1/output.html
@@ -105,7 +105,7 @@ folder2 (examples/git-generator/app/app-set.yaml)
 multi-source-app (examples/multi-source/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: backend (default)</h4>
+<h4 class="resource_header">Deployment: default/backend</h4>
 <div class="diff_container">
 <table>
 
@@ -117,7 +117,7 @@ multi-source-app (examples/multi-source/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: frontend (default)</h4>
+<h4 class="resource_header">Deployment: default/frontend</h4>
 <div class="diff_container">
 <table>
 
@@ -139,7 +139,7 @@ multi-source-app (examples/multi-source/app.yaml)
 nginx-ingress (examples/external-chart/nginx.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Deployment: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-1/target-1/output.md
+++ b/integration-test/branch-1/target-1/output.md
@@ -42,7 +42,7 @@ Modified (2):
 <summary>multi-source-app (examples/multi-source/app.yaml)</summary>
 <br>
 
-#### Deployment: backend (default)
+#### Deployment: default/backend
 ```diff
        - image: my-org/backend:1.0.0
          name: backend
@@ -50,7 +50,7 @@ Modified (2):
 -        - containerPort: 8080
 +        - containerPort: 80
 ```
-#### Deployment: frontend (default)
+#### Deployment: default/frontend
 ```diff
          app: frontend
      spec:
@@ -67,7 +67,7 @@ Modified (2):
 <summary>nginx-ingress (examples/external-chart/nginx.yaml)</summary>
 <br>
 
-#### Deployment: nginx-ingress-ingress-nginx-controller (default)
+#### Deployment: default/nginx-ingress-ingress-nginx-controller
 ```diff
                fieldPath: metadata.namespace
          - name: LD_PRELOAD

--- a/integration-test/branch-1/target-2/output.html
+++ b/integration-test/branch-1/target-2/output.html
@@ -104,7 +104,7 @@ folder2 (examples/git-generator/app/app-set.yaml)
 multi-source-app (examples/multi-source/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: backend (default)</h4>
+<h4 class="resource_header">Deployment: default/backend</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-1/target-2/output.md
+++ b/integration-test/branch-1/target-2/output.md
@@ -41,7 +41,7 @@ Modified (1):
 <summary>multi-source-app (examples/multi-source/app.yaml)</summary>
 <br>
 
-#### Deployment: backend (default)
+#### Deployment: default/backend
 ```diff
        app: backend
    template:

--- a/integration-test/branch-1/target-3/output.html
+++ b/integration-test/branch-1/target-3/output.html
@@ -81,7 +81,7 @@ folder2 [<a href="https://argocd.example.com/applications/folder2">link</a>] (ex
 multi-source-app [<a href="https://argocd.example.com/applications/multi-source-app">link</a>] (examples/multi-source/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: backend (default)</h4>
+<h4 class="resource_header">Deployment: default/backend</h4>
 <div class="diff_container">
 <table>
 
@@ -100,7 +100,7 @@ multi-source-app [<a href="https://argocd.example.com/applications/multi-source-
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: frontend (default)</h4>
+<h4 class="resource_header">Deployment: default/frontend</h4>
 <div class="diff_container">
 <table>
 
@@ -129,7 +129,7 @@ multi-source-app [<a href="https://argocd.example.com/applications/multi-source-
 nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/external-chart/nginx.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Deployment: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-1/target-3/output.md
+++ b/integration-test/branch-1/target-3/output.md
@@ -22,7 +22,7 @@ _Diff hidden because `--hide-deleted-app-diff` is enabled_
 <summary>multi-source-app [<a href="https://argocd.example.com/applications/multi-source-app">link</a>] (examples/multi-source/app.yaml)</summary>
 <br>
 
-#### Deployment: backend (default)
+#### Deployment: default/backend
 ```diff
        app: backend
    template:
@@ -37,7 +37,7 @@ _Diff hidden because `--hide-deleted-app-diff` is enabled_
 -        - containerPort: 8080
 +        - containerPort: 80
 ```
-#### Deployment: frontend (default)
+#### Deployment: default/frontend
 ```diff
    replicas: 2
    selector:
@@ -61,7 +61,7 @@ _Diff hidden because `--hide-deleted-app-diff` is enabled_
 <summary>nginx-ingress [<a href="https://argocd.example.com/applications/nginx-ingress">link</a>] (examples/external-chart/nginx.yaml)</summary>
 <br>
 
-#### Deployment: nginx-ingress-ingress-nginx-controller (default)
+#### Deployment: default/nginx-ingress-ingress-nginx-controller
 ```diff
          - name: POD_NAME
            valueFrom:

--- a/integration-test/branch-12/target-1/output.html
+++ b/integration-test/branch-12/target-1/output.html
@@ -68,7 +68,7 @@ pre {
 argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-applicationset-controller (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-applicationset-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -222,7 +222,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-dex-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-dex-server</h4>
 <div class="diff_container">
 <table>
 
@@ -320,7 +320,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-notifications-controller (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-notifications-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -416,7 +416,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-redis (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-redis</h4>
 <div class="diff_container">
 <table>
 
@@ -464,7 +464,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-repo-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-repo-server</h4>
 <div class="diff_container">
 <table>
 
@@ -664,7 +664,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-server</h4>
 <div class="diff_container">
 <table>
 
@@ -811,7 +811,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">StatefulSet: argocd-helm-chart-application-controller (argocd)</h4>
+<h4 class="resource_header">StatefulSet: argocd/argocd-helm-chart-application-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1044,7 +1044,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: argocd-helm-chart-application-controller (argocd)</h4>
+<h4 class="resource_header">Role: argocd/argocd-helm-chart-application-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1072,7 +1072,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: argocd-helm-chart-applicationset-controller (argocd)</h4>
+<h4 class="resource_header">Role: argocd/argocd-helm-chart-applicationset-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1103,7 +1103,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ConfigMap: argocd-cm (argocd)</h4>
+<h4 class="resource_header">ConfigMap: argocd/argocd-cm</h4>
 <div class="diff_container">
 <table>
 
@@ -1220,7 +1220,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ConfigMap: argocd-cmd-params-cm (argocd)</h4>
+<h4 class="resource_header">ConfigMap: argocd/argocd-cmd-params-cm</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-12/target-1/output.md
+++ b/integration-test/branch-12/target-1/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>argocd-helm-chart (examples/with-crds/applicaiton.yaml)</summary>
 <br>
 
-#### Deployment: argocd-helm-chart-applicationset-controller (argocd)
+#### Deployment: argocd/argocd-helm-chart-applicationset-controller
 ```diff
              configMapKeyRef:
                key: applicationsetcontroller.log.format
@@ -160,7 +160,7 @@ Modified (1):
 +          optional: true
 +        name: argocd-cmd-params-cm
 ```
-#### Deployment: argocd-helm-chart-dex-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-dex-server
 ```diff
                  matchLabels:
                    app.kubernetes.io/name: argocd-dex-server
@@ -254,7 +254,7 @@ Modified (1):
          secret:
            items:
 ```
-#### Deployment: argocd-helm-chart-notifications-controller (argocd)
+#### Deployment: argocd/argocd-helm-chart-notifications-controller
 ```diff
                labelSelector:
                  matchLabels:
@@ -346,7 +346,7 @@ Modified (1):
            items:
            - key: tls.crt
 ```
-#### Deployment: argocd-helm-chart-redis (argocd)
+#### Deployment: argocd/argocd-helm-chart-redis
 ```diff
          - ""
          - --appendonly
@@ -390,7 +390,7 @@ Modified (1):
        - configMap:
            defaultMode: 493
 ```
-#### Deployment: argocd-helm-chart-repo-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-repo-server
 ```diff
              configMapKeyRef:
                key: reposerver.log.format
@@ -586,7 +586,7 @@ Modified (1):
          name: var-files
        - emptyDir: {}
 ```
-#### Deployment: argocd-helm-chart-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-server
 ```diff
              configMapKeyRef:
                key: server.connection.status.cache.expiration
@@ -729,7 +729,7 @@ Modified (1):
            name: argocd-ssh-known-hosts-cm
          name: ssh-known-hosts
 ```
-#### StatefulSet: argocd-helm-chart-application-controller (argocd)
+#### StatefulSet: argocd/argocd-helm-chart-application-controller
 ```diff
              configMapKeyRef:
                key: controller.log.format
@@ -954,7 +954,7 @@ Modified (1):
    - ""
    resources:
 ```
-#### Role: argocd-helm-chart-application-controller (argocd)
+#### Role: argocd/argocd-helm-chart-application-controller
 ```diff
    - secrets
    - configmaps
@@ -978,7 +978,7 @@ Modified (1):
    - delete
  - apiGroups:
 ```
-#### Role: argocd-helm-chart-applicationset-controller (argocd)
+#### Role: argocd/argocd-helm-chart-applicationset-controller
 ```diff
    verbs:
    - get
@@ -1005,7 +1005,7 @@ Modified (1):
 -  - watch
 +  - create
 ```
-#### ConfigMap: argocd-cm (argocd)
+#### ConfigMap: argocd/argocd-cm
 ```diff
  apiVersion: v1
  data:
@@ -1118,7 +1118,7 @@ Modified (1):
      app.kubernetes.io/instance: argocd-helm-chart
      app.kubernetes.io/managed-by: Helm
 ```
-#### ConfigMap: argocd-cmd-params-cm (argocd)
+#### ConfigMap: argocd/argocd-cmd-params-cm
 ```diff
  apiVersion: v1
  data:
@@ -1631,7 +1631,8 @@ Modified (1):
                              uses the Kubernetes version of the target cluster.
                            type: string
 +                        labelIncludeTemplates:
-+                          description: LabelIncludeTemplates specifie
++                          description: LabelIncludeTemplates specifies whether to
++
 ```
 
 🚨 Diff is too long

--- a/integration-test/branch-12/target-2/output.html
+++ b/integration-test/branch-12/target-2/output.html
@@ -68,7 +68,7 @@ pre {
 argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-applicationset-controller (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-applicationset-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -222,7 +222,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-dex-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-dex-server</h4>
 <div class="diff_container">
 <table>
 
@@ -320,7 +320,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-notifications-controller (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-notifications-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -416,7 +416,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-redis (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-redis</h4>
 <div class="diff_container">
 <table>
 
@@ -464,7 +464,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-repo-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-repo-server</h4>
 <div class="diff_container">
 <table>
 
@@ -664,7 +664,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: argocd-helm-chart-server (argocd)</h4>
+<h4 class="resource_header">Deployment: argocd/argocd-helm-chart-server</h4>
 <div class="diff_container">
 <table>
 
@@ -811,7 +811,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">StatefulSet: argocd-helm-chart-application-controller (argocd)</h4>
+<h4 class="resource_header">StatefulSet: argocd/argocd-helm-chart-application-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1044,7 +1044,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: argocd-helm-chart-application-controller (argocd)</h4>
+<h4 class="resource_header">Role: argocd/argocd-helm-chart-application-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1072,7 +1072,7 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: argocd-helm-chart-applicationset-controller (argocd)</h4>
+<h4 class="resource_header">Role: argocd/argocd-helm-chart-applicationset-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1103,10 +1103,10 @@ argocd-helm-chart (examples/with-crds/applicaiton.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ConfigMap: argocd-cm (argocd)</h4>
+<h4 class="resource_header">ConfigMap: argocd/argocd-cm</h4>
 <p><em>Skipped</em></p>
 
-<h4 class="resource_header">ConfigMap: argocd-cmd-params-cm (argocd)</h4>
+<h4 class="resource_header">ConfigMap: argocd/argocd-cmd-params-cm</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-12/target-2/output.md
+++ b/integration-test/branch-12/target-2/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>argocd-helm-chart (examples/with-crds/applicaiton.yaml)</summary>
 <br>
 
-#### Deployment: argocd-helm-chart-applicationset-controller (argocd)
+#### Deployment: argocd/argocd-helm-chart-applicationset-controller
 ```diff
              configMapKeyRef:
                key: applicationsetcontroller.log.format
@@ -160,7 +160,7 @@ Modified (1):
 +          optional: true
 +        name: argocd-cmd-params-cm
 ```
-#### Deployment: argocd-helm-chart-dex-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-dex-server
 ```diff
                  matchLabels:
                    app.kubernetes.io/name: argocd-dex-server
@@ -254,7 +254,7 @@ Modified (1):
          secret:
            items:
 ```
-#### Deployment: argocd-helm-chart-notifications-controller (argocd)
+#### Deployment: argocd/argocd-helm-chart-notifications-controller
 ```diff
                labelSelector:
                  matchLabels:
@@ -346,7 +346,7 @@ Modified (1):
            items:
            - key: tls.crt
 ```
-#### Deployment: argocd-helm-chart-redis (argocd)
+#### Deployment: argocd/argocd-helm-chart-redis
 ```diff
          - ""
          - --appendonly
@@ -390,7 +390,7 @@ Modified (1):
        - configMap:
            defaultMode: 493
 ```
-#### Deployment: argocd-helm-chart-repo-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-repo-server
 ```diff
              configMapKeyRef:
                key: reposerver.log.format
@@ -586,7 +586,7 @@ Modified (1):
          name: var-files
        - emptyDir: {}
 ```
-#### Deployment: argocd-helm-chart-server (argocd)
+#### Deployment: argocd/argocd-helm-chart-server
 ```diff
              configMapKeyRef:
                key: server.connection.status.cache.expiration
@@ -729,7 +729,7 @@ Modified (1):
            name: argocd-ssh-known-hosts-cm
          name: ssh-known-hosts
 ```
-#### StatefulSet: argocd-helm-chart-application-controller (argocd)
+#### StatefulSet: argocd/argocd-helm-chart-application-controller
 ```diff
              configMapKeyRef:
                key: controller.log.format
@@ -954,7 +954,7 @@ Modified (1):
    - ""
    resources:
 ```
-#### Role: argocd-helm-chart-application-controller (argocd)
+#### Role: argocd/argocd-helm-chart-application-controller
 ```diff
    - secrets
    - configmaps
@@ -978,7 +978,7 @@ Modified (1):
    - delete
  - apiGroups:
 ```
-#### Role: argocd-helm-chart-applicationset-controller (argocd)
+#### Role: argocd/argocd-helm-chart-applicationset-controller
 ```diff
    verbs:
    - get
@@ -1005,11 +1005,11 @@ Modified (1):
 -  - watch
 +  - create
 ```
-#### ConfigMap: argocd-cm (argocd)
+#### ConfigMap: argocd/argocd-cm
 
 _Skipped_
 
-#### ConfigMap: argocd-cmd-params-cm (argocd)
+#### ConfigMap: argocd/argocd-cmd-params-cm
 ```diff
  apiVersion: v1
  data:

--- a/integration-test/branch-13/target-1/output.html
+++ b/integration-test/branch-13/target-1/output.html
@@ -68,7 +68,7 @@ pre {
 ignore-annotation-example (examples/ignore-annotation/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -121,7 +121,7 @@ ignore-annotation-example (examples/ignore-annotation/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -149,7 +149,7 @@ ignore-annotation-example (examples/ignore-annotation/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-13/target-1/output.md
+++ b/integration-test/branch-13/target-1/output.md
@@ -10,7 +10,7 @@ Added (1):
 <summary>ignore-annotation-example (examples/ignore-annotation/app.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (default)
+#### Deployment: default/super-app-name
 ```diff
 +apiVersion: apps/v1
 +kind: Deployment
@@ -59,7 +59,7 @@ Added (1):
 +      securityContext: {}
 +      serviceAccountName: super-app-name
 ```
-#### Service: super-app-name (default)
+#### Service: default/super-app-name
 ```diff
 +apiVersion: v1
 +kind: Service
@@ -83,7 +83,7 @@ Added (1):
 +    app.kubernetes.io/name: myApp
 +  type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (default)
+#### ServiceAccount: default/super-app-name
 ```diff
 +apiVersion: v1
 +automountServiceAccountToken: true

--- a/integration-test/branch-13/target-2/output.html
+++ b/integration-test/branch-13/target-2/output.html
@@ -68,7 +68,7 @@ pre {
 label-selectors-example (examples/label-selectors/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (some-namespace)</h4>
+<h4 class="resource_header">Deployment: some-namespace/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -121,7 +121,7 @@ label-selectors-example (examples/label-selectors/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (some-namespace)</h4>
+<h4 class="resource_header">Service: some-namespace/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -149,7 +149,7 @@ label-selectors-example (examples/label-selectors/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (some-namespace)</h4>
+<h4 class="resource_header">ServiceAccount: some-namespace/super-app-name</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-13/target-2/output.md
+++ b/integration-test/branch-13/target-2/output.md
@@ -10,7 +10,7 @@ Added (1):
 <summary>label-selectors-example (examples/label-selectors/app.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (some-namespace)
+#### Deployment: some-namespace/super-app-name
 ```diff
 +apiVersion: apps/v1
 +kind: Deployment
@@ -59,7 +59,7 @@ Added (1):
 +      securityContext: {}
 +      serviceAccountName: super-app-name
 ```
-#### Service: super-app-name (some-namespace)
+#### Service: some-namespace/super-app-name
 ```diff
 +apiVersion: v1
 +kind: Service
@@ -83,7 +83,7 @@ Added (1):
 +    app.kubernetes.io/name: myApp
 +  type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (some-namespace)
+#### ServiceAccount: some-namespace/super-app-name
 ```diff
 +apiVersion: v1
 +automountServiceAccountToken: true

--- a/integration-test/branch-15/target/output.html
+++ b/integration-test/branch-15/target/output.html
@@ -68,7 +68,7 @@ pre {
 order-change-example (examples/order-change/app/app-set.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment → StatefulSet: order-change-example-deploy-1 → order-change-example-sfs-1 (default)</h4>
+<h4 class="resource_header">Deployment → StatefulSet: default/order-change-example-deploy-1 → default/order-change-example-sfs-1</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-15/target/output.md
+++ b/integration-test/branch-15/target/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>order-change-example (examples/order-change/app/app-set.yaml)</summary>
 <br>
 
-#### Deployment → StatefulSet: order-change-example-deploy-1 → order-change-example-sfs-1 (default)
+#### Deployment → StatefulSet: default/order-change-example-deploy-1 → default/order-change-example-sfs-1
 ```diff
  apiVersion: apps/v1
 -kind: Deployment

--- a/integration-test/branch-16/target/output.html
+++ b/integration-test/branch-16/target/output.html
@@ -68,7 +68,7 @@ pre {
 my-app (examples/helm-kustomize-postrender/application.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: my-app (default)</h4>
+<h4 class="resource_header">Deployment: default/my-app</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-16/target/output.md
+++ b/integration-test/branch-16/target/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app (examples/helm-kustomize-postrender/application.yaml)</summary>
 <br>
 
-#### Deployment: my-app (default)
+#### Deployment: default/my-app
 ```diff
    template:
      metadata:

--- a/integration-test/branch-2/target/output.html
+++ b/integration-test/branch-2/target/output.html
@@ -68,7 +68,7 @@ pre {
 internal-chart-example (examples/internal-chart/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → new-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/new-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -113,7 +113,7 @@ internal-chart-example (examples/internal-chart/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → new-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/new-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -141,7 +141,7 @@ internal-chart-example (examples/internal-chart/app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → new-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/new-app-name</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-2/target/output.md
+++ b/integration-test/branch-2/target/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>internal-chart-example (examples/internal-chart/app.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → new-app-name (default)
+#### Deployment: default/super-app-name → default/new-app-name
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -51,7 +51,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: new-app-name
 ```
-#### Service: super-app-name → new-app-name (default)
+#### Service: default/super-app-name → default/new-app-name
 ```diff
  apiVersion: v1
  kind: Service
@@ -75,7 +75,7 @@ Modified (1):
      app.kubernetes.io/instance: internal-chart-example
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → new-app-name (default)
+#### ServiceAccount: default/super-app-name → default/new-app-name
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-3/target/output.html
+++ b/integration-test/branch-3/target/output.html
@@ -68,7 +68,7 @@ pre {
 my-service-staging (examples/kustomize/applications/my-service-staging.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: staging-myapp (default)</h4>
+<h4 class="resource_header">Deployment: default/staging-myapp</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-3/target/output.md
+++ b/integration-test/branch-3/target/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-service-staging (examples/kustomize/applications/my-service-staging.yaml)</summary>
 <br>
 
-#### Deployment: staging-myapp (default)
+#### Deployment: default/staging-myapp
 ```diff
  apiVersion: apps/v1
  kind: Deployment

--- a/integration-test/branch-5/target-1/output.html
+++ b/integration-test/branch-5/target-1/output.html
@@ -68,7 +68,7 @@ pre {
 my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -109,7 +109,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -137,7 +137,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-1/output.md
+++ b/integration-test/branch-5/target-1/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -47,7 +47,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -71,7 +71,7 @@ Modified (1):
      app.kubernetes.io/instance: my-app-watch-pattern-valid-regex
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-5/target-2/output.html
+++ b/integration-test/branch-5/target-2/output.html
@@ -68,7 +68,7 @@ pre {
 my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -109,7 +109,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -137,7 +137,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-2/output.md
+++ b/integration-test/branch-5/target-2/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -47,7 +47,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -71,7 +71,7 @@ Modified (1):
      app.kubernetes.io/instance: my-app-watch-pattern-valid-regex
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-5/target-4/output.html
+++ b/integration-test/branch-5/target-4/output.html
@@ -68,7 +68,7 @@ pre {
 my-app-labels [<a href="https://argocd.example.com/applications/my-app-labels">link</a>] (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -109,7 +109,7 @@ my-app-labels [<a href="https://argocd.example.com/applications/my-app-labels">l
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -137,7 +137,7 @@ my-app-labels [<a href="https://argocd.example.com/applications/my-app-labels">l
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-4/output.md
+++ b/integration-test/branch-5/target-4/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app-labels [<a href="https://argocd.example.com/applications/my-app-labels">link</a>] (examples/helm/applications/label-selectors/my-app-labels.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -47,7 +47,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -71,7 +71,7 @@ Modified (1):
      app.kubernetes.io/instance: my-app-labels
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-5/target-6/output.html
+++ b/integration-test/branch-5/target-6/output.html
@@ -68,7 +68,7 @@ pre {
 my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -109,7 +109,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -137,7 +137,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-6/output.md
+++ b/integration-test/branch-5/target-6/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -47,7 +47,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -71,7 +71,7 @@ Modified (1):
      app.kubernetes.io/instance: my-app-labels
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-5/target-8/output.html
+++ b/integration-test/branch-5/target-8/output.html
@@ -68,7 +68,7 @@ pre {
 my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -109,7 +109,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -137,7 +137,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-8/output.md
+++ b/integration-test/branch-5/target-8/output.md
@@ -10,7 +10,7 @@ Modified (1):
 <summary>my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -47,7 +47,7 @@ Modified (1):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -71,7 +71,7 @@ Modified (1):
      app.kubernetes.io/instance: my-app-labels
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-5/target-9/output.html
+++ b/integration-test/branch-5/target-9/output.html
@@ -69,7 +69,7 @@ pre {
 my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -110,7 +110,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -138,7 +138,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -165,7 +165,7 @@ my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)
 my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -206,7 +206,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 
@@ -234,7 +234,7 @@ my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → experiment (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/experiment</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-5/target-9/output.md
+++ b/integration-test/branch-5/target-9/output.md
@@ -11,7 +11,7 @@ Modified (2):
 <summary>my-app-labels (examples/helm/applications/label-selectors/my-app-labels.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -48,7 +48,7 @@ Modified (2):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -72,7 +72,7 @@ Modified (2):
      app.kubernetes.io/instance: my-app-labels
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true
@@ -94,7 +94,7 @@ Modified (2):
 <summary>my-app-watch-pattern-valid-regex (examples/helm/applications/watch-pattern/valid-regex.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → experiment (default)
+#### Deployment: default/super-app-name → default/experiment
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -131,7 +131,7 @@ Modified (2):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: experiment
 ```
-#### Service: super-app-name → experiment (default)
+#### Service: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  kind: Service
@@ -155,7 +155,7 @@ Modified (2):
      app.kubernetes.io/instance: my-app-watch-pattern-valid-regex
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → experiment (default)
+#### ServiceAccount: default/super-app-name → default/experiment
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-6/target/output.html
+++ b/integration-test/branch-6/target/output.html
@@ -178,7 +178,7 @@ app2 (examples/duplicate-names/app/app-set-2.yaml)
 my-app -&gt; my-super-app (examples/helm/applications/my-app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -219,7 +219,7 @@ my-app -&gt; my-super-app (examples/helm/applications/my-app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -249,7 +249,7 @@ my-app -&gt; my-super-app (examples/helm/applications/my-app.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -276,7 +276,7 @@ my-app -&gt; my-super-app (examples/helm/applications/my-app.yaml)
 my-service-staging (examples/kustomize/applications/my-service-staging.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: staging-myapp (default)</h4>
+<h4 class="resource_header">Deployment: default/staging-myapp</h4>
 <div class="diff_container">
 <table>
 
@@ -302,7 +302,7 @@ my-service-staging (examples/kustomize/applications/my-service-staging.yaml)
 nginx-ingress (examples/helm/applications/nginx.yaml -&gt; examples/helm/applications/nginx-new-path.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Deployment: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-6/target/output.md
+++ b/integration-test/branch-6/target/output.md
@@ -100,7 +100,7 @@ Modified (7):
 <summary>my-app -> my-super-app (examples/helm/applications/my-app.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (default)
+#### Deployment: default/super-app-name
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -137,7 +137,7 @@ Modified (7):
          livenessProbe:
            httpGet:
 ```
-#### Service: super-app-name (default)
+#### Service: default/super-app-name
 ```diff
  apiVersion: v1
  kind: Service
@@ -163,7 +163,7 @@ Modified (7):
      app.kubernetes.io/name: myApp
    type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (default)
+#### ServiceAccount: default/super-app-name
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true
@@ -185,7 +185,7 @@ Modified (7):
 <summary>my-service-staging (examples/kustomize/applications/my-service-staging.yaml)</summary>
 <br>
 
-#### Deployment: staging-myapp (default)
+#### Deployment: default/staging-myapp
 ```diff
      spec:
        containers:
@@ -206,7 +206,7 @@ Modified (7):
 <summary>nginx-ingress (examples/helm/applications/nginx.yaml -> examples/helm/applications/nginx-new-path.yaml)</summary>
 <br>
 
-#### Deployment: nginx-ingress-ingress-nginx-controller (default)
+#### Deployment: default/nginx-ingress-ingress-nginx-controller
 ```diff
          app.kubernetes.io/part-of: ingress-nginx
          app.kubernetes.io/version: 1.10.0

--- a/integration-test/branch-7/target/output.html
+++ b/integration-test/branch-7/target/output.html
@@ -69,7 +69,7 @@ pre {
 valid-manifest-generate-paths-example (examples/manifest-generate-paths/valid-annotation.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -110,7 +110,7 @@ valid-manifest-generate-paths-example (examples/manifest-generate-paths/valid-an
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -138,7 +138,7 @@ valid-manifest-generate-paths-example (examples/manifest-generate-paths/valid-an
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -165,7 +165,7 @@ valid-manifest-generate-paths-example (examples/manifest-generate-paths/valid-an
 watch-pattern-valid-regex-example (examples/watch-pattern/valid-regex.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -206,7 +206,7 @@ watch-pattern-valid-regex-example (examples/watch-pattern/valid-regex.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -234,7 +234,7 @@ watch-pattern-valid-regex-example (examples/watch-pattern/valid-regex.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name → super-duper-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name → default/super-duper-app-name</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-7/target/output.md
+++ b/integration-test/branch-7/target/output.md
@@ -11,7 +11,7 @@ Modified (2):
 <summary>valid-manifest-generate-paths-example (examples/manifest-generate-paths/valid-annotation.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → super-duper-app-name (default)
+#### Deployment: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -48,7 +48,7 @@ Modified (2):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: super-duper-app-name
 ```
-#### Service: super-app-name → super-duper-app-name (default)
+#### Service: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: v1
  kind: Service
@@ -72,7 +72,7 @@ Modified (2):
      app.kubernetes.io/instance: valid-manifest-generate-paths-example
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → super-duper-app-name (default)
+#### ServiceAccount: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true
@@ -94,7 +94,7 @@ Modified (2):
 <summary>watch-pattern-valid-regex-example (examples/watch-pattern/valid-regex.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name → super-duper-app-name (default)
+#### Deployment: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: apps/v1
  kind: Deployment
@@ -131,7 +131,7 @@ Modified (2):
 -      serviceAccountName: super-app-name
 +      serviceAccountName: super-duper-app-name
 ```
-#### Service: super-app-name → super-duper-app-name (default)
+#### Service: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: v1
  kind: Service
@@ -155,7 +155,7 @@ Modified (2):
      app.kubernetes.io/instance: watch-pattern-valid-regex-example
      app.kubernetes.io/name: myApp
 ```
-#### ServiceAccount: super-app-name → super-duper-app-name (default)
+#### ServiceAccount: default/super-app-name → default/super-duper-app-name
 ```diff
  apiVersion: v1
  automountServiceAccountToken: true

--- a/integration-test/branch-9/target-1/output.html
+++ b/integration-test/branch-9/target-1/output.html
@@ -208,7 +208,7 @@ app2 (examples/duplicate-names/app/app-set-2.yaml)
 custom-target-revision-example (examples/custom-target-revision/app/app.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: my-deployment (default)</h4>
+<h4 class="resource_header">Deployment: default/my-deployment</h4>
 <div class="diff_container">
 <table>
 
@@ -236,7 +236,7 @@ custom-target-revision-example (examples/custom-target-revision/app/app.yaml)
 my-app-set-dev (examples/basic-appset/my-app-set.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -289,7 +289,7 @@ my-app-set-dev (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -317,7 +317,7 @@ my-app-set-dev (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -343,7 +343,7 @@ my-app-set-dev (examples/basic-appset/my-app-set.yaml)
 my-app-set-prod (examples/basic-appset/my-app-set.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -396,7 +396,7 @@ my-app-set-prod (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -424,7 +424,7 @@ my-app-set-prod (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -450,7 +450,7 @@ my-app-set-prod (examples/basic-appset/my-app-set.yaml)
 my-app-set-staging (examples/basic-appset/my-app-set.yaml)
 </summary>
 
-<h4 class="resource_header">Deployment: super-app-name (default)</h4>
+<h4 class="resource_header">Deployment: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -503,7 +503,7 @@ my-app-set-staging (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: super-app-name (default)</h4>
+<h4 class="resource_header">Service: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -531,7 +531,7 @@ my-app-set-staging (examples/basic-appset/my-app-set.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: super-app-name (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/super-app-name</h4>
 <div class="diff_container">
 <table>
 
@@ -598,7 +598,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Deployment: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -864,7 +864,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">Role: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 
@@ -962,7 +962,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">RoleBinding: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">RoleBinding: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 
@@ -990,7 +990,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ConfigMap: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">ConfigMap: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1012,7 +1012,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Service: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -1052,7 +1052,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: nginx-ingress-ingress-nginx-controller-admission (default)</h4>
+<h4 class="resource_header">Service: default/nginx-ingress-ingress-nginx-controller-admission</h4>
 <div class="diff_container">
 <table>
 
@@ -1083,7 +1083,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/branch-9/target-1/output.md
+++ b/integration-test/branch-9/target-1/output.md
@@ -130,7 +130,7 @@ Deleted (9):
 <summary>custom-target-revision-example (examples/custom-target-revision/app/app.yaml)</summary>
 <br>
 
-#### Deployment: my-deployment (default)
+#### Deployment: default/my-deployment
 ```diff
 -apiVersion: apps/v1
 -kind: Deployment
@@ -153,7 +153,7 @@ Deleted (9):
 <summary>my-app-set-dev (examples/basic-appset/my-app-set.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (default)
+#### Deployment: default/super-app-name
 ```diff
 -apiVersion: apps/v1
 -kind: Deployment
@@ -202,7 +202,7 @@ Deleted (9):
 -      securityContext: {}
 -      serviceAccountName: super-app-name
 ```
-#### Service: super-app-name (default)
+#### Service: default/super-app-name
 ```diff
 -apiVersion: v1
 -kind: Service
@@ -226,7 +226,7 @@ Deleted (9):
 -    app.kubernetes.io/name: myApp
 -  type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (default)
+#### ServiceAccount: default/super-app-name
 ```diff
 -apiVersion: v1
 -automountServiceAccountToken: true
@@ -247,7 +247,7 @@ Deleted (9):
 <summary>my-app-set-prod (examples/basic-appset/my-app-set.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (default)
+#### Deployment: default/super-app-name
 ```diff
 -apiVersion: apps/v1
 -kind: Deployment
@@ -296,7 +296,7 @@ Deleted (9):
 -      securityContext: {}
 -      serviceAccountName: super-app-name
 ```
-#### Service: super-app-name (default)
+#### Service: default/super-app-name
 ```diff
 -apiVersion: v1
 -kind: Service
@@ -320,7 +320,7 @@ Deleted (9):
 -    app.kubernetes.io/name: myApp
 -  type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (default)
+#### ServiceAccount: default/super-app-name
 ```diff
 -apiVersion: v1
 -automountServiceAccountToken: true
@@ -341,7 +341,7 @@ Deleted (9):
 <summary>my-app-set-staging (examples/basic-appset/my-app-set.yaml)</summary>
 <br>
 
-#### Deployment: super-app-name (default)
+#### Deployment: default/super-app-name
 ```diff
 -apiVersion: apps/v1
 -kind: Deployment
@@ -390,7 +390,7 @@ Deleted (9):
 -      securityContext: {}
 -      serviceAccountName: super-app-name
 ```
-#### Service: super-app-name (default)
+#### Service: default/super-app-name
 ```diff
 -apiVersion: v1
 -kind: Service
@@ -414,7 +414,7 @@ Deleted (9):
 -    app.kubernetes.io/name: myApp
 -  type: ClusterIP
 ```
-#### ServiceAccount: super-app-name (default)
+#### ServiceAccount: default/super-app-name
 ```diff
 -apiVersion: v1
 -automountServiceAccountToken: true

--- a/integration-test/branch-9/target-2/output.html
+++ b/integration-test/branch-9/target-2/output.html
@@ -109,7 +109,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Deployment: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Deployment: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -375,7 +375,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Role: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">Role: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 
@@ -473,7 +473,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">RoleBinding: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">RoleBinding: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 
@@ -501,7 +501,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ConfigMap: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">ConfigMap: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -523,7 +523,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: nginx-ingress-ingress-nginx-controller (default)</h4>
+<h4 class="resource_header">Service: default/nginx-ingress-ingress-nginx-controller</h4>
 <div class="diff_container">
 <table>
 
@@ -563,7 +563,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">Service: nginx-ingress-ingress-nginx-controller-admission (default)</h4>
+<h4 class="resource_header">Service: default/nginx-ingress-ingress-nginx-controller-admission</h4>
 <div class="diff_container">
 <table>
 
@@ -594,7 +594,7 @@ nginx-ingress (examples/external-chart/nginx.yaml)
 </table>
 </div>
 
-<h4 class="resource_header">ServiceAccount: nginx-ingress-ingress-nginx (default)</h4>
+<h4 class="resource_header">ServiceAccount: default/nginx-ingress-ingress-nginx</h4>
 <div class="diff_container">
 <table>
 

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -104,10 +104,10 @@ var testCases = []TestCase{
 		BaseBranch:   "integration-test/branch-3/base",
 	},
 	{
-		Name:                       "branch-4/target",
-		TargetBranch:               "integration-test/branch-4/target",
-		BaseBranch:                 "integration-test/branch-4/base",
-		Title:                      "integration-test/branch-4",
+		Name:         "branch-4/target",
+		TargetBranch: "integration-test/branch-4/target",
+		BaseBranch:   "integration-test/branch-4/base",
+		Title:        "integration-test/branch-4",
 	},
 	{
 		Name:                       "branch-5/target-1",
@@ -396,8 +396,8 @@ func TestIntegration(t *testing.T) {
 			}
 		}
 
-		// Create cluster if: every 8th test, no cluster exists, or test explicitly requires it
-		createCluster := testsSinceClusterCreation >= 8 || !clusterExists || tc.CreateCluster == "true"
+		// Create cluster if: every 15th test, no cluster exists, or test explicitly requires it
+		createCluster := testsSinceClusterCreation >= 15 || !clusterExists || tc.CreateCluster == "true"
 		if createCluster {
 			testsSinceClusterCreation = 0
 		}

--- a/pkg/diff/generator_test.go
+++ b/pkg/diff/generator_test.go
@@ -236,7 +236,7 @@ func TestBuildMatchingSections_WithResources(t *testing.T) {
 	if len(md[0].resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(md[0].resources))
 	}
-	if md[0].resources[0].Header != "Deployment: my-deploy (default)" {
+	if md[0].resources[0].Header != "Deployment: default/my-deploy" {
 		t.Errorf("expected resource header, got %q", md[0].resources[0].Header)
 	}
 

--- a/pkg/matching/integration_test.go
+++ b/pkg/matching/integration_test.go
@@ -1162,8 +1162,8 @@ spec:
 	if resource.Name != "my-app" {
 		t.Errorf("expected resource name=my-app, got %s", resource.Name)
 	}
-	if resource.Header() != "Deployment → StatefulSet: my-app (default)" {
-		t.Errorf("expected header 'Deployment → StatefulSet: my-app (default)', got %q", resource.Header())
+	if resource.Header() != "Deployment → StatefulSet: default/my-app" {
+		t.Errorf("expected header 'Deployment → StatefulSet: default/my-app', got %q", resource.Header())
 	}
 
 	// The diff content should show the kind change

--- a/pkg/matching/matching_test.go
+++ b/pkg/matching/matching_test.go
@@ -1706,7 +1706,7 @@ func TestBuildResourceDiffs_SkippedResourceHeader(t *testing.T) {
 		t.Error("expected resource to be marked as skipped")
 	}
 	// CRDs are cluster-scoped (no namespace), so header should be Kind: Name without parens
-	expectedHeader := "CustomResourceDefinition: apps.example.com"
+	expectedHeader := "CustomResourceDefinition: apps.example.com" // cluster-scoped, no namespace
 	if result[0].Header() != expectedHeader {
 		t.Errorf("expected header %q, got %q", expectedHeader, result[0].Header())
 	}
@@ -1862,7 +1862,7 @@ func TestResourceDiff_Header(t *testing.T) {
 			diff: ResourceDiff{
 				Kind: "Deployment", Name: "my-app", Namespace: "default",
 			},
-			expected: "Deployment: my-app (default)",
+			expected: "Deployment: default/my-app",
 		},
 		{
 			name: "cluster-scoped resource (no namespace)",
@@ -1877,7 +1877,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Kind: "StatefulSet", OldKind: "Deployment",
 				Name: "my-app", Namespace: "default",
 			},
-			expected: "Deployment → StatefulSet: my-app (default)",
+			expected: "Deployment → StatefulSet: default/my-app",
 		},
 		{
 			name: "name change",
@@ -1886,7 +1886,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Name: "new-name", OldName: "old-name",
 				Namespace: "default",
 			},
-			expected: "Deployment: old-name → new-name (default)",
+			expected: "Deployment: default/old-name → default/new-name",
 		},
 		{
 			name: "namespace change",
@@ -1894,7 +1894,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Kind: "Deployment", Name: "my-app",
 				Namespace: "production", OldNamespace: "staging",
 			},
-			expected: "Deployment: my-app (staging → production)",
+			expected: "Deployment: staging/my-app → production/my-app",
 		},
 		{
 			name: "kind and name change",
@@ -1903,7 +1903,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Name: "new-app", OldName: "old-app",
 				Namespace: "default",
 			},
-			expected: "Deployment → StatefulSet: old-app → new-app (default)",
+			expected: "Deployment → StatefulSet: default/old-app → default/new-app",
 		},
 		{
 			name: "all three change",
@@ -1912,7 +1912,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Name: "new-app", OldName: "old-app",
 				Namespace: "prod", OldNamespace: "dev",
 			},
-			expected: "Deployment → StatefulSet: old-app → new-app (dev → prod)",
+			expected: "Deployment → StatefulSet: dev/old-app → prod/new-app",
 		},
 		{
 			name: "old kind same as new kind (no arrow)",
@@ -1920,7 +1920,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Kind: "Deployment", OldKind: "Deployment",
 				Name: "my-app", Namespace: "default",
 			},
-			expected: "Deployment: my-app (default)",
+			expected: "Deployment: default/my-app",
 		},
 		{
 			name: "old name same as new name (no arrow)",
@@ -1929,7 +1929,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Name: "my-app", OldName: "my-app",
 				Namespace: "default",
 			},
-			expected: "Deployment: my-app (default)",
+			expected: "Deployment: default/my-app",
 		},
 		{
 			name: "old namespace same as new namespace (no arrow)",
@@ -1937,7 +1937,7 @@ func TestResourceDiff_Header(t *testing.T) {
 				Kind: "Deployment", Name: "my-app",
 				Namespace: "default", OldNamespace: "default",
 			},
-			expected: "Deployment: my-app (default)",
+			expected: "Deployment: default/my-app",
 		},
 	}
 

--- a/pkg/matching/output.go
+++ b/pkg/matching/output.go
@@ -28,10 +28,11 @@ type ResourceDiff struct {
 }
 
 // Header returns a display header for the resource.
-// Format: "Kind: Name (Namespace)" with arrows for changes:
-//   - Kind change:      "OldKind → NewKind: Name (Namespace)"
-//   - Name change:      "Kind: OldName → NewName (Namespace)"
-//   - Namespace change: "Kind: Name (OldNs → NewNs)"
+// Format: "Kind: namespace/Name" with arrows for changes:
+//   - Kind change:      "OldKind → NewKind: namespace/Name"
+//   - Name change:      "Kind: namespace/OldName → namespace/NewName"
+//   - Namespace change: "Kind: oldNs/Name → newNs/Name"
+//   - Cluster-scoped:   "Kind: Name" (no namespace prefix)
 func (r *ResourceDiff) Header() string {
 	// Kind part
 	kindStr := r.Kind
@@ -39,24 +40,30 @@ func (r *ResourceDiff) Header() string {
 		kindStr = fmt.Sprintf("%s → %s", r.OldKind, r.Kind)
 	}
 
-	// Name part
-	nameStr := r.Name
-	if r.OldName != "" && r.OldName != r.Name {
-		nameStr = fmt.Sprintf("%s → %s", r.OldName, r.Name)
+	// Namespace/Name part — expressed as "namespace/name" or just "name" if cluster-scoped
+	nsChanged := r.OldNamespace != "" && r.OldNamespace != r.Namespace
+	nameChanged := r.OldName != "" && r.OldName != r.Name
+
+	qualifiedName := func(ns, name string) string {
+		if ns == "" {
+			return name
+		}
+		return fmt.Sprintf("%s/%s", ns, name)
 	}
 
-	header := fmt.Sprintf("%s: %s", kindStr, nameStr)
-
-	// Namespace part
-	nsStr := r.Namespace
-	if r.OldNamespace != "" && r.OldNamespace != r.Namespace {
-		nsStr = fmt.Sprintf("%s → %s", r.OldNamespace, r.Namespace)
+	oldNs := r.OldNamespace
+	if oldNs == "" {
+		oldNs = r.Namespace
+	}
+	oldName := r.OldName
+	if oldName == "" {
+		oldName = r.Name
 	}
 
-	if nsStr != "" {
-		return fmt.Sprintf("%s (%s)", header, nsStr)
+	if nsChanged || nameChanged {
+		return fmt.Sprintf("%s: %s → %s", kindStr, qualifiedName(oldNs, oldName), qualifiedName(r.Namespace, r.Name))
 	}
-	return header
+	return fmt.Sprintf("%s: %s", kindStr, qualifiedName(r.Namespace, r.Name))
 }
 
 // AppDiff represents the diff output for a single application pair


### PR DESCRIPTION
## Summary

Changes the per-resource section header format from:

```
#### Deployment: staging-myapp (default)
#### Deployment → StatefulSet: old-app → new-app (dev → prod)
```

to:

```
#### Deployment: default/staging-myapp
#### Deployment → StatefulSet: dev/old-app → prod/new-app
```