### PR TITLE
Fix | Support repo-creds credential templates in repo-server-api render method

### DIFF
--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -96,11 +96,15 @@ func RenderApplicationsFromBothBranches(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get list of namespaced scoped resources: %w", err)
 	}
 
+	// Collect all unique repository URLs referenced by the Applications so that
+	// FetchRepoCreds can enrich them with credentials from repo-creds templates.
+	appRepoURLs := collectRepoURLs(baseApps, targetApps)
+
 	// Fetch all repository credentials from the cluster once, upfront.
 	// The repo server has no access to Kubernetes secrets - credentials must be
 	// provided by the caller in every ManifestRequest. We mirror what the
 	// ArgoCD app controller does in controller/state.go before calling the repo server.
-	creds, err := FetchRepoCreds(context.Background(), argocd.K8sClient, argocd.Namespace)
+	creds, err := FetchRepoCreds(context.Background(), argocd.K8sClient, argocd.Namespace, appRepoURLs)
 	if err != nil {
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to fetch repository credentials: %w", err)
 	}
@@ -353,6 +357,55 @@ func renderApp(
 	}
 
 	return filtered, nil
+}
+
+// collectRepoURLs extracts all unique repository URLs referenced by the given
+// Application resources (from both base and target branches). It inspects
+// spec.source.repoURL and spec.sources[*].repoURL. The result is deduplicated
+// by the normalised URL form.
+//
+// NOTE: by the time apps reach the repo-server-extract path, ApplicationSets
+// have already been converted to Applications, so we only need to look under
+// spec (not spec.template.spec).
+func collectRepoURLs(appLists ...[]argoapplication.ArgoResource) []string {
+	seen := make(map[string]bool)
+	var urls []string
+
+	for _, apps := range appLists {
+		for _, app := range apps {
+			obj := app.Yaml.Object
+
+			// spec.source.repoURL (single-source apps)
+			if repoURL, found, _ := unstructured.NestedString(obj, "spec", "source", "repoURL"); found && repoURL != "" {
+				key := normalizeRepoURL(repoURL)
+				if !seen[key] {
+					seen[key] = true
+					urls = append(urls, repoURL)
+				}
+			}
+
+			// spec.sources[*].repoURL (multi-source apps)
+			if sourcesRaw, found, _ := unstructured.NestedSlice(obj, "spec", "sources"); found {
+				for _, srcRaw := range sourcesRaw {
+					srcMap, ok := srcRaw.(map[string]any)
+					if !ok {
+						continue
+					}
+					repoURL, _ := srcMap["repoURL"].(string)
+					if repoURL == "" {
+						continue
+					}
+					key := normalizeRepoURL(repoURL)
+					if !seen[key] {
+						seen[key] = true
+						urls = append(urls, repoURL)
+					}
+				}
+			}
+		}
+	}
+
+	return urls
 }
 
 // splitSources parses the application's spec.sources / spec.source and splits

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -596,3 +596,93 @@ func TestNormalizeRepoURL(t *testing.T) {
 		assert.Equal(t, tc.want, normalizeRepoURL(tc.input), "input: %s", tc.input)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// collectRepoURLs
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestCollectRepoURLs_SingleSource(t *testing.T) {
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/org/repo.git
+    path: apps/my-app
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+`)
+	urls := collectRepoURLs([]argoapplication.ArgoResource{app})
+	assert.Equal(t, []string{"https://github.com/org/repo.git"}, urls)
+}
+
+func TestCollectRepoURLs_MultiSource(t *testing.T) {
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  sources:
+    - repoURL: https://github.com/org/repo.git
+      path: apps/my-app
+      ref: values
+    - repoURL: https://charts.jetstack.io
+      chart: cert-manager
+      targetRevision: "1.12.0"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+`)
+	urls := collectRepoURLs([]argoapplication.ArgoResource{app})
+	assert.Len(t, urls, 2)
+	assert.Contains(t, urls, "https://github.com/org/repo.git")
+	assert.Contains(t, urls, "https://charts.jetstack.io")
+}
+
+func TestCollectRepoURLs_Deduplication(t *testing.T) {
+	app1 := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app1
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/org/repo.git
+    path: apps/app1
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+`)
+	app2 := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app2
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/org/repo
+    path: apps/app2
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+`)
+	// Same URL with and without .git — should deduplicate to one entry
+	urls := collectRepoURLs(
+		[]argoapplication.ArgoResource{app1},
+		[]argoapplication.ArgoResource{app2},
+	)
+	assert.Len(t, urls, 1)
+}
+
+func TestCollectRepoURLs_Empty(t *testing.T) {
+	urls := collectRepoURLs([]argoapplication.ArgoResource{})
+	assert.Empty(t, urls)
+}

--- a/pkg/reposerverextract/repocreds.go
+++ b/pkg/reposerverextract/repocreds.go
@@ -58,7 +58,18 @@ type RepoCreds struct {
 // FetchRepoCreds connects to the cluster via the ArgoCD DB layer and fetches
 // all repository and credential information registered under the given
 // ArgoCD namespace. The returned RepoCreds is safe for concurrent read access.
-func FetchRepoCreds(ctx context.Context, k8sClient *k8s.Client, namespace string) (*RepoCreds, error) {
+//
+// appRepoURLs is the set of repository URLs referenced by all Applications that
+// will be rendered. For each URL, FetchRepoCreds calls argoDB.GetRepository()
+// which—unlike ListRepositories—also inherits credentials from "repo-creds"
+// type secrets (credential templates) via prefix matching. This mirrors the
+// enrichment path used by the ArgoCD app controller in controller/state.go.
+//
+// Without this, users who only configure a repo-creds secret (common for
+// GitHub token authentication across many repositories) would get bare stubs
+// with no credentials, causing "authentication required" errors from the repo
+// server.
+func FetchRepoCreds(ctx context.Context, k8sClient *k8s.Client, namespace string, appRepoURLs []string) (*RepoCreds, error) {
 	// The ArgoCD DB requires a typed kubernetes.Interface.  Our K8sClient
 	// exposes the underlying *rest.Config so we can build one on demand.
 	typedClient, err := kubernetes.NewForConfig(k8sClient.GetConfig())
@@ -105,13 +116,39 @@ func FetchRepoCreds(ctx context.Context, k8sClient *k8s.Client, namespace string
 		reposByURL[normalizeRepoURL(r.Repo)] = r
 	}
 
-	if len(helmRepos)+len(ociRepos)+len(helmRepoCreds)+len(ociRepoCreds)+len(allRepos) > 0 {
+	// ── Credential-template inheritance for app repo URLs ────────────────────
+	// ListRepositories only returns repos that have an explicit "repository"
+	// type secret. Users who rely solely on "repo-creds" (credential templates)
+	// won't have their URLs in the list above. For those URLs we call
+	// argoDB.GetRepository() which creates a bare Repository and then enriches
+	// it via the repo-creds prefix-matching path — exactly what the ArgoCD app
+	// controller does in controller/state.go before calling the repo server.
+	repoCredTemplates := 0
+	for _, rawURL := range appRepoURLs {
+		key := normalizeRepoURL(rawURL)
+		if _, exists := reposByURL[key]; exists {
+			continue // already have credentials from a "repository" secret
+		}
+		repo, err := argoDB.GetRepository(ctx, rawURL, "")
+		if err != nil {
+			log.Warn().Err(err).Str("repoURL", rawURL).
+				Msg("⚠️ Failed to look up repository credentials for app repo URL")
+			continue
+		}
+		if repo.HasCredentials() {
+			reposByURL[key] = repo
+			repoCredTemplates++
+		}
+	}
+
+	if len(helmRepos)+len(ociRepos)+len(helmRepoCreds)+len(ociRepoCreds)+len(allRepos)+repoCredTemplates > 0 {
 		log.Info().
 			Int("helmRepos", len(helmRepos)).
 			Int("ociRepos", len(ociRepos)).
 			Int("helmRepoCreds", len(helmRepoCreds)).
 			Int("ociRepoCreds", len(ociRepoCreds)).
 			Int("repos", len(allRepos)).
+			Int("repoCredTemplates", repoCredTemplates).
 			Msg("📦 Fetched ArgoCD repository credentials from cluster")
 	}
 


### PR DESCRIPTION
## Summary

- Fixes `authentication required` errors when using `--render-method=repo-server-api` with `repo-creds` type secrets (credential templates)
- `FetchRepoCreds` now calls `argoDB.GetRepository()` for each app repo URL not already covered by a `repository`-type secret, which triggers ArgoCD's credential template inheritance via prefix matching - the same path the ArgoCD app controller uses in `controller/state.go`
- Adds `collectRepoURLs` helper to extract all unique repo URLs from the Application list before credential fetching

## Context

Users who configure credentials via `argocd.argoproj.io/secret-type: repo-creds` (credential templates with prefix matching) instead of per-repo `repository`-type secrets would get bare stubs with no credentials when using the `repo-server-api` render method. This is because `ListRepositories()` only returns repos with explicit `repository`-type secrets. The `repo-creds` template only kicks in when `GetRepository()` is called for a specific URL, which creates a bare `Repository` and enriches it via prefix matching.

Related issue: #355