### PR TITLE
Fix | Use substring match for prRepo comparison to support owner/repo slug format

### DIFF
--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -543,7 +543,7 @@ func buildManifestRequestForSource(
 		// repository than the PR repo. Those files are not checked out
 		// locally, so we cannot stream them. Fall back to the remote
 		// GenerateManifest RPC and let the repo server fetch them itself.
-		if prRepo != "" && normalizeRepoURL(primarySource.RepoURL) != normalizeRepoURL(prRepo) {
+		if prRepo != "" && !repoURLContains(primarySource.RepoURL, prRepo) {
 			log.Debug().
 				Str("App", app.GetLongName()).
 				Str("sourceRepoURL", primarySource.RepoURL).
@@ -615,7 +615,7 @@ func buildManifestRequestForSource(
 	// cannot stream its files locally. Use the remote RPC and let the repo
 	// server fetch both the primary content and the ref sources from their
 	// respective git caches. Value-file $ref/… paths are left unrewritten.
-	if prRepo != "" && normalizeRepoURL(primarySource.RepoURL) != normalizeRepoURL(prRepo) {
+	if prRepo != "" && !repoURLContains(primarySource.RepoURL, prRepo) {
 		log.Debug().
 			Str("App", app.GetLongName()).
 			Str("sourceRepoURL", primarySource.RepoURL).

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -598,6 +598,130 @@ func TestNormalizeRepoURL(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// repoURLContains - substring match used for prRepo comparisons
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRepoURLContains(t *testing.T) {
+	cases := []struct {
+		name    string
+		repoURL string
+		substr  string
+		want    bool
+	}{
+		{
+			name:    "full URL matches full URL",
+			repoURL: "https://github.com/org/repo.git",
+			substr:  "https://github.com/org/repo.git",
+			want:    true,
+		},
+		{
+			name:    "slug matches full URL",
+			repoURL: "https://github.com/org/repo.git",
+			substr:  "org/repo",
+			want:    true,
+		},
+		{
+			name:    "slug matches full URL without .git",
+			repoURL: "https://github.com/org/repo",
+			substr:  "org/repo",
+			want:    true,
+		},
+		{
+			name:    "case insensitive",
+			repoURL: "https://github.com/Org/Repo.git",
+			substr:  "org/repo",
+			want:    true,
+		},
+		{
+			name:    "different repos do not match",
+			repoURL: "https://github.com/org/repo-a.git",
+			substr:  "org/repo-b",
+			want:    false,
+		},
+		{
+			name:    "different orgs do not match",
+			repoURL: "https://github.com/org-a/repo.git",
+			substr:  "org-b/repo",
+			want:    false,
+		},
+		{
+			name:    "GitLab full URL with slug",
+			repoURL: "https://gitlab.com/company/project.git",
+			substr:  "company/project",
+			want:    true,
+		},
+		{
+			name:    "Bitbucket full URL with slug",
+			repoURL: "https://bitbucket.org/team/repo.git",
+			substr:  "team/repo",
+			want:    true,
+		},
+		{
+			name:    "empty substr matches anything",
+			repoURL: "https://github.com/org/repo.git",
+			substr:  "",
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, repoURLContains(tc.repoURL, tc.substr), "repoURL=%q substr=%q", tc.repoURL, tc.substr)
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Same-repo source with prRepo as owner/repo slug → streams locally
+//
+//	When the user passes --repo=owner/repo (the documented format), the
+//	source repoURL is a full URL like "https://github.com/owner/repo.git".
+//	The comparison must use substring matching so the slug is recognised as
+//	belonging to the same repository.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+func TestBuildManifestRequest_SameRepoSource_WithSlugPrRepo_StreamsLocally(t *testing.T) {
+	// prRepo is the short "owner/repo" slug — the documented format for --repo.
+	prRepo := "aaronshifman/my-private-repo"
+	branchFolder := makeBranchFolder(t, "apps/debezium/debezium")
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: debezium-operator
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/aaronshifman/my-private-repo.git
+    path: apps/debezium/debezium
+    plugin:
+      name: kustomize-build-with-helm-oci
+    targetRevision: main
+  destination:
+    namespace: debezium-operator
+    server: https://kubernetes.default.svc
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, prRepo)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// CRITICAL: must stream locally — the source is in the same repo.
+	// Before the fix, the slug format caused a mismatch and fell into the
+	// remote RPC path, which failed with "authentication required".
+	assert.Equal(t, branchFolder, streamDir,
+		"REGRESSION: same-repo source with slug-format prRepo must stream locally, not use remote RPC")
+	assert.Equal(t, "apps/debezium/debezium", req.ApplicationSource.Path)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // collectRepoURLs
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/pkg/reposerverextract/repocreds.go
+++ b/pkg/reposerverextract/repocreds.go
@@ -192,6 +192,17 @@ func normalizeRepoURL(u string) string {
 	return u
 }
 
+// repoURLContains reports whether the normalised form of repoURL contains the
+// normalised form of substr. This is used to match source repoURLs against the
+// --repo flag value which can be either a full URL
+// ("https://github.com/org/repo.git") or a short slug ("org/repo").
+//
+// Using a substring match (like the patching code's containsIgnoreCase) keeps
+// the comparison provider-agnostic — we don't assume GitHub, GitLab, etc.
+func repoURLContains(repoURL, substr string) bool {
+	return strings.Contains(normalizeRepoURL(repoURL), normalizeRepoURL(substr))
+}
+
 // HelmRepos returns the Helm + OCI repository lists to pass as
 // ManifestRequest.Repos. For OCI primary sources the OCI list is merged in
 // (mirrors controller/state.go behaviour).


### PR DESCRIPTION
## Summary

- Fixes `authentication required` / remote-RPC-fallback errors when using `--render-method=repo-server-api` and the `--repo` flag is set to the documented `owner/repo` slug format (e.g. `aaronshifman/my-repo`)
- Replaces the `normalizeRepoURL(sourceURL) != normalizeRepoURL(prRepo)` equality check with a `repoURLContains` substring match — the same approach already used by the patching code (`containsIgnoreCase`)
- Adds `repoURLContains` helper in `repocreds.go` and tests in `extract_test.go` covering GitHub, GitLab, Bitbucket, case-insensitivity, `.git` suffix variations, and the exact aaronshifman regression scenario

## Context

The `--repo` flag is documented as `OWNER/REPO` (e.g. `aaronshifman/my-repo`), but Application manifests use full URLs (e.g. `https://github.com/aaronshifman/my-repo.git`). The previous equality check after `normalizeRepoURL` would never match a slug against a full URL, so every source — including same-repo sources — was incorrectly classified as cross-repo and sent through the remote `GenerateManifest` RPC. For users with private repos whose repo-server doesn't have the repo pre-cached, this caused `authentication required` errors.

The fix uses a substring `contains` check (provider-agnostic — works for GitHub, GitLab, Bitbucket, etc.) so that `aaronshifman/my-repo` correctly matches `https://github.com/aaronshifman/my-repo.git`, routing same-repo sources back to the local streaming path.

Related issue: #355