### PR TITLE
Docs | Clarify app-of-apps support and reorganize Helm/Kustomize explanation

### DIFF
--- a/docs/app-of-apps.md
+++ b/docs/app-of-apps.md
@@ -1,24 +1,34 @@
 # App of Apps
 
-!!! warning "🧪 Experimental"
-    App of Apps support is an experimental feature. The behaviour and flags described on this page may change in future releases without a deprecation notice.
-
 The [App of Apps pattern](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/) is a common Argo CD pattern where a parent Application renders child Application manifests. The parent application points to a directory of Application YAML files, and Argo CD creates those child applications automatically.
 
-Without App of Apps support, `argocd-diff-preview` renders only the applications it discovers directly in your repository files. Child applications that are *generated* by a parent - and therefore never exist as files in the repo - are invisible to the tool.
+`argocd-diff-preview` already works with the App of Apps pattern **out of the box** - as long as the child Applications (or ApplicationSets) exist as plain YAML manifests in your repository. The tool scans your repository files, finds every `kind: Application` and `kind: ApplicationSet`, and renders them all.
 
-With the `--traverse-app-of-apps` flag, `argocd-diff-preview` can discover and render those child applications automatically.
+However, if your child Applications are *generated* at render time by a parent - for example, a root Application that points to a Helm chart which templates child Application manifests - they never exist as files in the repo. In that case you need either pre-rendering or the `--traverse-app-of-apps` flag.
 
 ---
 
-## Consider alternatives first
+## When you don't need `--traverse-app-of-apps`
 
-!!! tip "Prefer simpler alternatives when possible"
-    The `--traverse-app-of-apps` feature is **slower** and **more limited** than the standard rendering flow. Before enabling it, consider whether one of the alternatives below covers your use case.
+If your child Applications are committed as plain YAML files in the repository, the tool picks them up automatically. No extra flags needed.
 
-**Pre-render your Application manifests**
+---
 
-If your applications do not exist as plain manifests inside the repo, but are instead generated from Helm or Kustomize, you can pre-render them in your CI pipeline and place the output in the branch folder. `argocd-diff-preview` will then pick them up as regular files. See [Helm/Kustomize generated Argo CD applications](./generated-applications.md) for details and examples.
+## When you do need it
+
+If child Applications are generated dynamically (e.g. by a Helm chart or Kustomize overlay inside a parent Application), they are invisible to the file scanner. You have two options:
+
+### Option 1: Pre-render your Application manifests
+
+If your applications are generated from Helm or Kustomize, you can pre-render them in your CI pipeline and place the output in the branch folder. `argocd-diff-preview` will then pick them up as regular files. See [Helm/Kustomize generated Argo CD applications](./generated-applications.md) for details and examples.
+
+### Option 2: Use `--traverse-app-of-apps`
+
+!!! warning "🧪 Experimental"
+    The `--traverse-app-of-apps` flag is an experimental feature. Its behaviour may change in future releases without a deprecation notice.
+
+!!! tip "Prefer pre-rendering when possible"
+    The `--traverse-app-of-apps` flag is **slower** and **more limited** than the standard rendering flow. Consider [pre-rendering](./generated-applications.md) first.
 
 Only use `--traverse-app-of-apps` when the child Applications are *not* committed as plain manifests to the repository AND can *not* be pre-rendered easily.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,26 +59,24 @@ Comparing to live cluster state introduces non-determinism and ambiguity. The cl
 
 ---
 
-### Does it work with the Apps of Apps Pattern?
+### Does it work with the App of Apps Pattern?
 
-**Short answer:** Yes, but it depends on your setup.
+**Short answer:** Yes.
 
-**Longer answer:** The Apps of Apps Pattern can be configured in many ways, making it challenging to handle all cases. This tool identifies and renders all resources with `kind: Application` or `kind: ApplicationSet`. If your Applications or ApplicationSets are written as plain manifests in your repository, the tool will work seamlessly. However, if you have an Application that deploys a Helm chart, which then deploys the rest of your Applications, you will need to render the Helm chart before running the tool.
+**Longer answer:** The tool scans your repository for all resources with `kind: Application` or `kind: ApplicationSet` and renders them. If your child Applications exist as plain YAML manifests in the repository, the tool works out of the box - no extra flags needed.
 
-Relevant issue: [#75](https://github.com/dag-andersen/argocd-diff-preview/issues/75)
+If your child Applications are *generated dynamically* at render time (e.g. a root Application that deploys a Helm chart which templates child Application manifests), the tool cannot see them by default. In that case you can either:
+
+1. **Pre-render** the Application manifests in your CI pipeline before running `argocd-diff-preview`. See [Helm/Kustomize generated Argo CD applications](./generated-applications.md).
+2. **Use `--traverse-app-of-apps`** (🧪 experimental) to let the tool discover and render child Applications automatically at runtime.
+
+More info: [App of Apps docs](./app-of-apps.md)
+
+Relevant issues: [#41](https://github.com/dag-andersen/argocd-diff-preview/issues/41), [#75](https://github.com/dag-andersen/argocd-diff-preview/issues/75), [#200](https://github.com/dag-andersen/argocd-diff-preview/issues/200), [#381](https://github.com/dag-andersen/argocd-diff-preview/issues/381)
 
 #### Why can't the tool automatically render my Helm Charts or Kustomize templates?
 
-Helm and Kustomize configurations are inherently complex:
-
-- **Helm:** Any YAML file can be used as a values file for Helm charts, making it impossible for the tool to automatically determine which YAML files should be used as values files and which Helm charts they belong to.
-- **Kustomize:** Overlays in Kustomize can be chained in various ways. The tool cannot reliably figure out which overlays to use or skip.
-
-Because of this, users must render their Helm charts and Kustomize templates before running the tool.
-
-The tool is rather conservative in making assumptions about how Applications are rendered, with the goal of avoiding false positives.
-
-More info: [docs](./generated-applications.md)
+The tool intentionally avoids guessing how to render Helm charts and Kustomize templates - the configurations are ambiguous by nature, and incorrect assumptions would lead to misleading diffs. See the [generated applications docs](./generated-applications.md#why-cant-the-tool-do-this-automatically) for details.
 
 ---
 
@@ -86,7 +84,7 @@ More info: [docs](./generated-applications.md)
 
 **Short answer:** Yes
 
-**Longer answer:** Yes, but it deepends on how complicated your setup is. Check out the [multi-repo](./multi-repo.md) documentation to learn how to use the tool with a distributed Argo CD repository setup.
+**Longer answer:** Yes, but it depends on how complicated your setup is. Check out the [multi-repo](./multi-repo.md) documentation to learn how to use the tool with a distributed Argo CD repository setup.
 
 ---
 

--- a/docs/generated-applications.md
+++ b/docs/generated-applications.md
@@ -2,6 +2,15 @@
 
 `argocd-diff-preview` discovers applications by scanning your repository for YAML files with `kind: Application` or `kind: ApplicationSet`. If your Application manifests are not committed directly to the repository but are instead *generated* by a Helm chart or Kustomize template, you need to render them first and place the output somewhere in the branch folder before running the tool.
 
+### Why can't the tool do this automatically?
+
+Helm and Kustomize configurations are inherently complex:
+
+- **Helm:** Any YAML file can be used as a values file for Helm charts, making it impossible for the tool to automatically determine which YAML files should be used as values files and which Helm charts they belong to.
+- **Kustomize:** Overlays in Kustomize can be chained in various ways. The tool cannot reliably figure out which overlays to use or skip.
+
+Because of this, the tool is conservative and avoids making assumptions about how Applications are rendered - with the goal of avoiding false positives.
+
 ---
 
 ## Example scenario


### PR DESCRIPTION
## Summary

- Clarify that app-of-apps works out of the box when child apps are plain YAML - only `--traverse-app-of-apps` is experimental
- Move the Helm/Kustomize "why can't the tool do this automatically" explanation to `generated-applications.md` and link from the FAQ
- Update FAQ app-of-apps section to match current capabilities