### PR TITLE
Fix | Show helpful message when --max-diff-length is too small to display diff

### DIFF
--- a/pkg/diff/markdown.go
+++ b/pkg/diff/markdown.go
@@ -191,7 +191,12 @@ func (m *MarkdownOutput) printDiff(maxDiffMessageCharCount uint) string {
 	}
 
 	if sectionsDiff.Len() == 0 {
-		sectionsDiff.WriteString("No changes found")
+		if len(m.sections) > 0 {
+			sectionsDiff.WriteString(fmt.Sprintf("⚠️ Changes were found but `--max-diff-length` (%d) is too small to display them. Increase the value or check the HTML output instead.", maxDiffMessageCharCount))
+			log.Warn().Msgf("🚨 --max-diff-length (%d) is too small to display any diff content. Increase the value or use the HTML output instead.", maxDiffMessageCharCount)
+		} else {
+			sectionsDiff.WriteString("No changes found")
+		}
 	}
 
 	output = strings.ReplaceAll(output, "%info_box%", m.statsInfo.String())

--- a/pkg/diff/markdown_test.go
+++ b/pkg/diff/markdown_test.go
@@ -213,6 +213,35 @@ func TestMarkdownOutput_PrintDiff(t *testing.T) {
 			},
 		},
 		{
+			name: "Extremely small max-diff-length shows helpful message instead of no changes found",
+			output: MarkdownOutput{
+				title:   "Tiny Diff",
+				summary: "Some changes",
+				sections: []MarkdownSection{
+					{
+						appName:  "My App",
+						filePath: "path/to/app.yaml",
+						appURL:   "",
+						resources: []ResourceSection{
+							{Header: "@@ Application modified: My App @@", Content: "+ new line\n- old line\n"},
+						},
+					},
+				},
+				statsInfo: StatsInfo{
+					ApplicationCount: 1,
+				},
+			},
+			maxSize:                 3, // Extremely small - like the user in issue #392
+			maxDiffMessageCharCount: 3,
+			expectedContains: []string{
+				"too small to display them",
+				"--max-diff-length",
+			},
+			expectedNotContains: []string{
+				"No changes found",
+			},
+		},
+		{
 			name: "Truncated output shows warning",
 			output: MarkdownOutput{
 				title:   "Large Diff",


### PR DESCRIPTION
## Summary

- When `--max-diff-length` is set too small to fit any diff content, the markdown output now shows a helpful warning instead of the misleading "No changes found" message.
- Adds a warning log line so users also see the issue in CLI output.
- Adds a test case reproducing the exact scenario from #392.