### PR TITLE
Fix | Resolve golangci-lint warnings for modernize and staticcheck

### DIFF
--- a/pkg/diff/markdown.go
+++ b/pkg/diff/markdown.go
@@ -192,7 +192,7 @@ func (m *MarkdownOutput) printDiff(maxDiffMessageCharCount uint) string {
 
 	if sectionsDiff.Len() == 0 {
 		if len(m.sections) > 0 {
-			sectionsDiff.WriteString(fmt.Sprintf("⚠️ Changes were found but `--max-diff-length` (%d) is too small to display them. Increase the value or check the HTML output instead.", maxDiffMessageCharCount))
+			fmt.Fprintf(&sectionsDiff, "⚠️ Changes were found but `--max-diff-length` (%d) is too small to display them. Increase the value or check the HTML output instead.", maxDiffMessageCharCount)
 			log.Warn().Msgf("🚨 --max-diff-length (%d) is too small to display any diff content. Increase the value or use the HTML output instead.", maxDiffMessageCharCount)
 		} else {
 			sectionsDiff.WriteString("No changes found")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,10 +50,10 @@ func CreateFolder(path string, override bool) error {
 	return err
 }
 
-var uniqueNumber uint64
+var uniqueNumber atomic.Uint64
 
 func UniqueNumber() uint64 {
-	return atomic.AddUint64(&uniqueNumber, 1)
+	return uniqueNumber.Add(1)
 }
 
 func UniqueId() string {


### PR DESCRIPTION
## Summary

- Use `atomic.Uint64` instead of plain `uint64` + `atomic.AddUint64` in `pkg/utils/utils.go` (modernize)
- Use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` in `pkg/diff/markdown.go` (staticcheck)

Both issues were flagged by `golangci-lint run`.