### PR TITLE
Enable support for clusters using GKE fleet connect gateway

### DIFF
--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -32,14 +33,35 @@ func (c *Client) PortForwardToPod(namespace, podName string, localPort, remotePo
 		Name(podName).
 		SubResource("portforward")
 
-	// Create SPDY transport for the connection
+	// Create both WebSocket and SPDY dialers for compatibility
+	// GKE Connect Gateway requires WebSocket with SPDY protocol (Sec-WebSocket-Protocol: SPDY/3.1)
+	// Traditional clusters accept direct SPDY upgrade without WebSocket wrapping
+
+	// Create SPDY dialer (fallback for clusters)
 	transport, upgrader, err := spdy.RoundTripperFor(c.config)
 	if err != nil {
 		return fmt.Errorf("failed to create SPDY round tripper: %w", err)
 	}
+	spdyDialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
 
-	// Create dialer
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+	// Create WebSocket tunneling dialer (required for GKE Connect Gateway)
+	websocketDialer, err := portforward.NewSPDYOverWebsocketDialer(req.URL(), c.config)
+	if err != nil {
+		return fmt.Errorf("failed to create WebSocket dialer: %w", err)
+	}
+
+	// Use fallback pattern: try WebSocket first, fallback to SPDY on upgrade failures
+	dialer := portforward.NewFallbackDialer(
+		websocketDialer,
+		spdyDialer,
+		func(err error) bool {
+			shouldFallback := httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+			if shouldFallback {
+				log.Debug().Err(err).Msg("WebSocket upgrade failed, falling back to SPDY")
+			}
+			return shouldFallback
+		},
+	)
 
 	// Set up port forwarding
 	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -1,0 +1,45 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// TestFallbackCondition validates that WebSocket failures trigger SPDY fallback
+func TestFallbackCondition(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		shouldFallback bool
+	}{
+		{
+			name:           "upgrade failure triggers fallback",
+			err:            &httpstream.UpgradeFailureError{Cause: fmt.Errorf("upgrade failed")},
+			shouldFallback: true,
+		},
+		{
+			name:           "other errors do not trigger fallback",
+			err:            fmt.Errorf("network timeout"),
+			shouldFallback: false,
+		},
+		{
+			name:           "nil error does not trigger fallback",
+			err:            nil,
+			shouldFallback: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This is the exact condition from PortForwardToPod:60
+			result := httpstream.IsUpgradeFailure(tt.err) || httpstream.IsHTTPSProxyError(tt.err)
+
+			if result != tt.shouldFallback {
+				t.Errorf("expected %v, got %v for error: %v",
+					tt.shouldFallback, result, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Thanks for this project! It seems really promising! 

I ran into an issue when trying to get it setup on our GKE cluster.

When I run argocd-diff-preview with --render-method=repo-server-api and --traverse-app-of-apps, I end up with this error:

```
Error 400 (Bad Request)
  error upgrading connection: unable to upgrade connection
```

Looking into it, it seems like GKE clusters using Fleet/Connect Gateway connect using WebSocket + SPDY. I tried to then setup an implementation where it will try the websocket connection first then fallback to the previous method. This is working for me, but am not super confident the fallback mechanism is robust.