### PR TITLE
Fix | Avoid false diffs by setting Helm releaseName when unset

### DIFF
--- a/pkg/argoapplication/patching.go
+++ b/pkg/argoapplication/patching.go
@@ -80,6 +80,12 @@ func PatchApplication(
 		return nil, fmt.Errorf("failed to redirect source hydrator: %w", err)
 	}
 
+	err = app.SetHelmReleaseNameIfUnset()
+	if err != nil {
+		log.Info().Msgf("❌ Failed to patch application: %s", app.GetLongName())
+		return nil, fmt.Errorf("failed to set Helm releaseName: %w", err)
+	}
+
 	err = app.RedirectSources(repo, branch.Name, redirectRevisions)
 	if err != nil {
 		log.Info().Msgf("❌ Failed to patch application: %s", app.GetLongName())
@@ -93,6 +99,67 @@ func PatchApplication(
 	}
 
 	return &app, nil
+}
+
+// SetHelmReleaseNameIfUnset ensures Helm chart sources use a stable releaseName.
+//
+// Argo CD defaults Helm releaseName to Application metadata.name when unset.
+// argocd-diff-preview prefixes Application names at render time to isolate base and
+// target runs, which can leak into chart resource names and create false-positive
+// diffs when names are truncated. Setting releaseName to the original app name
+// keeps Helm naming stable across branches.
+//
+// This only applies to Application resources and only for Helm chart sources
+// (source.chart or sources[].chart). Existing releaseName values are preserved.
+func (a *ArgoResource) SetHelmReleaseNameIfUnset() error {
+	if a.Kind != Application || a.Yaml == nil {
+		return nil
+	}
+
+	if strings.TrimSpace(a.Name) == "" {
+		return nil
+	}
+
+	spec, found, _ := unstructured.NestedMap(a.Yaml.Object, "spec")
+	if !found {
+		return nil
+	}
+
+	if source, ok := spec["source"].(map[string]any); ok {
+		setHelmReleaseNameIfUnsetOnSource(source, a.Name)
+	}
+
+	if sources, ok := spec["sources"].([]any); ok {
+		for _, sourceInterface := range sources {
+			if source, ok := sourceInterface.(map[string]any); ok {
+				setHelmReleaseNameIfUnsetOnSource(source, a.Name)
+			}
+		}
+	}
+
+	if err := unstructured.SetNestedMap(a.Yaml.Object, spec, "spec"); err != nil {
+		return fmt.Errorf("failed to set spec map: %w", err)
+	}
+
+	return nil
+}
+
+func setHelmReleaseNameIfUnsetOnSource(source map[string]any, appName string) {
+	if _, hasChart := source["chart"]; !hasChart {
+		return
+	}
+
+	helmMap, ok := source["helm"].(map[string]any)
+	if !ok {
+		helmMap = make(map[string]any)
+		source["helm"] = helmMap
+	}
+
+	if _, exists := helmMap["releaseName"]; exists {
+		return
+	}
+
+	helmMap["releaseName"] = appName
 }
 
 // SetNamespace sets the namespace of the resource

--- a/pkg/argoapplication/patching_test.go
+++ b/pkg/argoapplication/patching_test.go
@@ -763,6 +763,168 @@ spec:
 	}
 }
 
+func TestSetHelmReleaseNameIfUnset(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.FatalLevel)
+
+	tests := []struct {
+		name     string
+		kind     ApplicationKind
+		appName  string
+		inputYML string
+		wantYML  string
+	}{
+		{
+			name:    "single helm source gets releaseName when unset",
+			kind:    Application,
+			appName: "non-prod-clickhouse-operator",
+			inputYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: non-prod-clickhouse-operator
+spec:
+  source:
+    repoURL: ghcr.io/clickhouse
+    chart: clickhouse-operator-helm
+    targetRevision: 0.0.4
+`,
+			wantYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: non-prod-clickhouse-operator
+spec:
+  source:
+    repoURL: ghcr.io/clickhouse
+    chart: clickhouse-operator-helm
+    targetRevision: 0.0.4
+    helm:
+      releaseName: non-prod-clickhouse-operator
+`,
+		},
+		{
+			name:    "existing releaseName is preserved",
+			kind:    Application,
+			appName: "non-prod-clickhouse-operator",
+			inputYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: non-prod-clickhouse-operator
+spec:
+  source:
+    repoURL: ghcr.io/clickhouse
+    chart: clickhouse-operator-helm
+    targetRevision: 0.0.4
+    helm:
+      releaseName: already-set
+`,
+			wantYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: non-prod-clickhouse-operator
+spec:
+  source:
+    repoURL: ghcr.io/clickhouse
+    chart: clickhouse-operator-helm
+    targetRevision: 0.0.4
+    helm:
+      releaseName: already-set
+`,
+		},
+		{
+			name:    "multi-source only sets chart sources",
+			kind:    Application,
+			appName: "my-app",
+			inputYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  sources:
+    - repoURL: https://github.com/org/repo
+      path: apps/my-app
+      targetRevision: main
+    - repoURL: ghcr.io/clickhouse
+      chart: clickhouse-operator-helm
+      targetRevision: 0.0.4
+`,
+			wantYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  sources:
+    - repoURL: https://github.com/org/repo
+      path: apps/my-app
+      targetRevision: main
+    - repoURL: ghcr.io/clickhouse
+      chart: clickhouse-operator-helm
+      targetRevision: 0.0.4
+      helm:
+        releaseName: my-app
+`,
+		},
+		{
+			name:    "applicationset is not modified",
+			kind:    ApplicationSet,
+			appName: "set-name",
+			inputYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: set-name
+spec:
+  template:
+    spec:
+      source:
+        repoURL: ghcr.io/clickhouse
+        chart: clickhouse-operator-helm
+        targetRevision: 0.0.4
+`,
+			wantYML: `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: set-name
+spec:
+  template:
+    spec:
+      source:
+        repoURL: ghcr.io/clickhouse
+        chart: clickhouse-operator-helm
+        targetRevision: 0.0.4
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var node map[string]any
+			err := yaml.Unmarshal([]byte(tt.inputYML), &node)
+			assert.NoError(t, err)
+
+			app := &ArgoResource{
+				Yaml:     &unstructured.Unstructured{Object: node},
+				Kind:     tt.kind,
+				Id:       "test-id",
+				Name:     tt.appName,
+				FileName: "test.yaml",
+			}
+
+			err = app.SetHelmReleaseNameIfUnset()
+			assert.NoError(t, err)
+
+			got, err := app.AsString()
+			assert.NoError(t, err)
+			assert.Equal(t, normalizeYAML(tt.wantYML), normalizeYAML(got))
+		})
+	}
+}
+
 // normalizeYAML normalizes YAML strings by parsing and re-marshaling
 func normalizeYAML(yamlStr string) string {
 	var node map[string]any


### PR DESCRIPTION
## Summary
- Set Helm releaseName on Application Helm chart sources when it is not already set, using the original Application name.
- Keep existing releaseName values unchanged and apply logic to both spec.source and spec.sources[] chart entries.
- Add tests covering unset, pre-set, multi-source, and ApplicationSet non-modification behavior.

## Why
- Argo CD defaults Helm releaseName to Application metadata.name when unset.
- argocd-diff-preview temporarily prefixes Application names during rendering, which can leak into chart resource names and cause false-positive diffs when names are truncated.
- Setting a stable releaseName avoids these false-positive diffs at the source.