### PR TITLE
Feat | Add render controls and diff reliability improvements

### DIFF
--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -14,9 +14,22 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// RenderMode controls whether an application should be rendered
+type RenderMode string
+
+const (
+	// RenderAlways means the application is always rendered, even if identical between branches
+	RenderAlways RenderMode = "always"
+	// RenderNever means the application is never rendered (same as ignore: true)
+	RenderNever RenderMode = "never"
+	// RenderChanged means the application is only rendered if it changed between branches (default)
+	RenderChanged RenderMode = "changed"
+)
+
 const (
 	annotationWatchPattern = "argocd-diff-preview/watch-pattern"
 	annotationIgnore       = "argocd-diff-preview/ignore"
+	annotationRender       = "argocd-diff-preview/render"
 )
 
 type ApplicationSelectionOptions struct {
@@ -137,13 +150,56 @@ func (a *ArgoResource) filterByIgnoreAnnotation() (bool, string) {
 	// get annotations
 	annotations, found, err := unstructured.NestedStringMap(a.Yaml.Object, "metadata", "annotations")
 	if err != nil || !found || len(annotations) == 0 {
-		return true, "no 'argocd-diff-preview/ignore' annotation found"
+		return true, "no 'argocd-diff-preview/ignore' or 'argocd-diff-preview/render' annotation found"
 	}
 
+	// Check the new render annotation first (takes precedence)
+	if value, exists := annotations[annotationRender]; exists {
+		switch RenderMode(strings.ToLower(strings.TrimSpace(value))) {
+		case RenderNever:
+			return false, fmt.Sprintf("application is ignored because of '%s: %s'", annotationRender, value)
+		case RenderAlways, RenderChanged:
+			return true, fmt.Sprintf("application is selected because of '%s: %s'", annotationRender, value)
+		default:
+			log.Warn().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("⚠️ Unknown value '%s' for annotation '%s'. Expected 'always', 'never', or 'changed'. Defaulting to 'changed'.", value, annotationRender)
+			return true, fmt.Sprintf("unknown render annotation value '%s', defaulting to 'changed'", value)
+		}
+	}
+
+	// Fall back to legacy ignore annotation
 	if value, exists := annotations[annotationIgnore]; exists && value == "true" {
 		return false, fmt.Sprintf("application is ignored because of '%s: %s'", annotationIgnore, value)
 	}
 	return true, "application is not ignored"
+}
+
+// GetRenderMode returns the render mode for the application based on annotations
+func (a *ArgoResource) GetRenderMode() RenderMode {
+	if a.Yaml == nil {
+		return RenderChanged
+	}
+
+	annotations, found, err := unstructured.NestedStringMap(a.Yaml.Object, "metadata", "annotations")
+	if err != nil || !found || len(annotations) == 0 {
+		return RenderChanged
+	}
+
+	if value, exists := annotations[annotationRender]; exists {
+		mode := RenderMode(strings.ToLower(strings.TrimSpace(value)))
+		switch mode {
+		case RenderAlways, RenderNever, RenderChanged:
+			return mode
+		default:
+			return RenderChanged
+		}
+	}
+
+	// Legacy: treat ignore=true as never
+	if value, exists := annotations[annotationIgnore]; exists && value == "true" {
+		return RenderNever
+	}
+
+	return RenderChanged
 }
 
 // filterBySelectors checks if the application matches the given selectors

--- a/pkg/argoapplication/filter_render_mode_test.go
+++ b/pkg/argoapplication/filter_render_mode_test.go
@@ -1,0 +1,114 @@
+package argoapplication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetRenderMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    *ArgoResource
+		expectedMode RenderMode
+	}{
+		{
+			name:        "nil yaml defaults to changed",
+			resource:    &ArgoResource{Yaml: nil},
+			expectedMode: RenderChanged,
+		},
+		{
+			name: "no annotations defaults to changed",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{},
+			}}},
+			expectedMode: RenderChanged,
+		},
+		{
+			name: "render always",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "always",
+					},
+				},
+			}}},
+			expectedMode: RenderAlways,
+		},
+		{
+			name: "render never",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "never",
+					},
+				},
+			}}},
+			expectedMode: RenderNever,
+		},
+		{
+			name: "render changed",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "changed",
+					},
+				},
+			}}},
+			expectedMode: RenderChanged,
+		},
+		{
+			name: "render always with whitespace and casing",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "  AlWaYs  ",
+					},
+				},
+			}}},
+			expectedMode: RenderAlways,
+		},
+		{
+			name: "invalid render value defaults to changed",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "true",
+					},
+				},
+			}}},
+			expectedMode: RenderChanged,
+		},
+		{
+			name: "legacy ignore true maps to render never",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/ignore": "true",
+					},
+				},
+			}}},
+			expectedMode: RenderNever,
+		},
+		{
+			name: "render annotation takes precedence over legacy ignore",
+			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"argocd-diff-preview/render": "always",
+						"argocd-diff-preview/ignore": "true",
+					},
+				},
+			}}},
+			expectedMode: RenderAlways,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.resource.GetRenderMode()
+			assert.Equal(t, tt.expectedMode, actual)
+		})
+	}
+}

--- a/pkg/duplicates/duplicates.go
+++ b/pkg/duplicates/duplicates.go
@@ -14,6 +14,12 @@ func RemoveIdenticalCopiesBetweenBranches(baseApps, targetApps *argoapplication.
 	for _, baseApp := range baseApps.SelectedApps {
 		for _, targetApp := range targetApps.SelectedApps {
 			if baseApp.Id == targetApp.Id && yamlEqual(baseApp.Yaml, targetApp.Yaml) {
+				if shouldAlwaysRender(baseApp, targetApp) {
+					log.Debug().
+						Str(baseApp.Kind.ShortName(), baseApp.Name).
+						Msg("Keeping application because `argocd-diff-preview/render=always`")
+					break
+				}
 				log.Debug().Str(baseApp.Kind.ShortName(), baseApp.Name).Msg("Skipping application because it has not changed")
 				duplicateYaml = append(duplicateYaml, baseApp.Yaml)
 				break
@@ -58,6 +64,10 @@ func RemoveIdenticalCopiesBetweenBranches(baseApps, targetApps *argoapplication.
 	}
 
 	return baseAppsDeDuplication, targetAppsDeDuplication
+}
+
+func shouldAlwaysRender(baseApp, targetApp argoapplication.ArgoResource) bool {
+	return baseApp.GetRenderMode() == argoapplication.RenderAlways || targetApp.GetRenderMode() == argoapplication.RenderAlways
 }
 
 func filterDuplicates(apps *argoapplication.ArgoSelection, duplicates []*unstructured.Unstructured) *argoapplication.ArgoSelection {

--- a/pkg/duplicates/duplicates_test.go
+++ b/pkg/duplicates/duplicates_test.go
@@ -31,9 +31,47 @@ spec:
 	return &obj
 }
 
+func createTestYAMLWithAnnotations(kind, name, namespace string, annotations map[string]string) *unstructured.Unstructured {
+	annotationLines := ""
+	if len(annotations) > 0 {
+		annotationLines = "\n  annotations:"
+		for key, value := range annotations {
+			annotationLines += "\n    " + key + ": \"" + value + "\""
+		}
+	}
+
+	yamlStr := `apiVersion: argoproj.io/v1alpha1
+kind: ` + kind + `
+metadata:
+  name: ` + name + `
+  namespace: ` + namespace + annotationLines + `
+spec:
+  destination:
+    namespace: ` + namespace
+
+	var obj unstructured.Unstructured
+	err := yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		panic(err)
+	}
+	return &obj
+}
+
 // Helper function to create test ArgoResource
 func createTestArgoResource(kind, name, fileName string, branch git.BranchType) argoapplication.ArgoResource {
 	yamlObj := createTestYAML(kind, name, "default")
+	var appKind argoapplication.ApplicationKind
+	if kind == "Application" {
+		appKind = argoapplication.Application
+	} else {
+		appKind = argoapplication.ApplicationSet
+	}
+
+	return *argoapplication.NewArgoResource(yamlObj, appKind, name, name, fileName, branch)
+}
+
+func createTestArgoResourceWithAnnotations(kind, name, fileName string, branch git.BranchType, annotations map[string]string) argoapplication.ArgoResource {
+	yamlObj := createTestYAMLWithAnnotations(kind, name, "default", annotations)
 	var appKind argoapplication.ApplicationKind
 	if kind == "Application" {
 		appKind = argoapplication.Application
@@ -248,4 +286,96 @@ func TestFilterDuplicates_PreservesExistingSkippedApps(t *testing.T) {
 	assert.Len(t, result.SelectedApps, 1)
 	assert.Equal(t, "app2", result.SelectedApps[0].Name)
 	assert.Len(t, result.SkippedApps, 2) // skippedApp + app1
+}
+
+func TestRemoveIdenticalCopiesBetweenBranches_ApplicationSetWithRenderAlwaysIsNotRemoved(t *testing.T) {
+	baseAppSet := createTestArgoResourceWithAnnotations(
+		"ApplicationSet",
+		"appset-1",
+		"appset.yaml",
+		git.Base,
+		map[string]string{"argocd-diff-preview/render": "always"},
+	)
+	targetAppSet := createTestArgoResourceWithAnnotations(
+		"ApplicationSet",
+		"appset-1",
+		"appset.yaml",
+		git.Target,
+		map[string]string{"argocd-diff-preview/render": "always"},
+	)
+
+	base := createArgoSelection([]argoapplication.ArgoResource{baseAppSet})
+	target := createArgoSelection([]argoapplication.ArgoResource{targetAppSet})
+
+	baseResult, targetResult := RemoveIdenticalCopiesBetweenBranches(base, target)
+
+	assert.Len(t, baseResult.SelectedApps, 1)
+	assert.Len(t, targetResult.SelectedApps, 1)
+	assert.Equal(t, "appset-1", baseResult.SelectedApps[0].Name)
+	assert.Equal(t, "appset-1", targetResult.SelectedApps[0].Name)
+	assert.Len(t, baseResult.SkippedApps, 0)
+	assert.Len(t, targetResult.SkippedApps, 0)
+}
+
+func TestRemoveIdenticalCopiesBetweenBranches_ApplicationSetWithoutRenderAlwaysIsRemoved(t *testing.T) {
+	baseAppSet := createTestArgoResource("ApplicationSet", "appset-2", "appset.yaml", git.Base)
+	targetAppSet := createTestArgoResource("ApplicationSet", "appset-2", "appset.yaml", git.Target)
+
+	base := createArgoSelection([]argoapplication.ArgoResource{baseAppSet})
+	target := createArgoSelection([]argoapplication.ArgoResource{targetAppSet})
+
+	baseResult, targetResult := RemoveIdenticalCopiesBetweenBranches(base, target)
+
+	assert.Len(t, baseResult.SelectedApps, 0)
+	assert.Len(t, targetResult.SelectedApps, 0)
+	assert.Len(t, baseResult.SkippedApps, 1)
+	assert.Len(t, targetResult.SkippedApps, 1)
+}
+
+func TestRemoveIdenticalCopiesBetweenBranches_ApplicationSetWithRenderAlwaysOnOneSideIsNotRemoved(t *testing.T) {
+	baseAppSet := createTestArgoResourceWithAnnotations(
+		"ApplicationSet",
+		"appset-3",
+		"appset.yaml",
+		git.Base,
+		map[string]string{"argocd-diff-preview/render": "always"},
+	)
+	targetAppSet := createTestArgoResource("ApplicationSet", "appset-3", "appset.yaml", git.Target)
+
+	base := createArgoSelection([]argoapplication.ArgoResource{baseAppSet})
+	target := createArgoSelection([]argoapplication.ArgoResource{targetAppSet})
+
+	baseResult, targetResult := RemoveIdenticalCopiesBetweenBranches(base, target)
+
+	assert.Len(t, baseResult.SelectedApps, 1)
+	assert.Len(t, targetResult.SelectedApps, 1)
+	assert.Len(t, baseResult.SkippedApps, 0)
+	assert.Len(t, targetResult.SkippedApps, 0)
+}
+
+func TestRemoveIdenticalCopiesBetweenBranches_ApplicationSetWithRenderChangedIsRemoved(t *testing.T) {
+	baseAppSet := createTestArgoResourceWithAnnotations(
+		"ApplicationSet",
+		"appset-4",
+		"appset.yaml",
+		git.Base,
+		map[string]string{"argocd-diff-preview/render": "changed"},
+	)
+	targetAppSet := createTestArgoResourceWithAnnotations(
+		"ApplicationSet",
+		"appset-4",
+		"appset.yaml",
+		git.Target,
+		map[string]string{"argocd-diff-preview/render": "changed"},
+	)
+
+	base := createArgoSelection([]argoapplication.ArgoResource{baseAppSet})
+	target := createArgoSelection([]argoapplication.ArgoResource{targetAppSet})
+
+	baseResult, targetResult := RemoveIdenticalCopiesBetweenBranches(base, target)
+
+	assert.Len(t, baseResult.SelectedApps, 0)
+	assert.Len(t, targetResult.SelectedApps, 0)
+	assert.Len(t, baseResult.SkippedApps, 1)
+	assert.Len(t, targetResult.SkippedApps, 1)
 }

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -84,7 +84,7 @@ func (c *Client) DeleteArgoCDApplication(namespace string, name string) error {
 // and matching the given label key
 func (c *Client) DeleteAllApplicationsOlderThan(namespace string, minutes int) error {
 
-	log.Info().Msgf("Deleting applications older than %d minutes", minutes)
+	log.Info().Msgf("⏳ Deleting applications older than %d minutes", minutes)
 
 	deletedCount := 0
 
@@ -111,9 +111,9 @@ func (c *Client) DeleteAllApplicationsOlderThan(namespace string, minutes int) e
 	}
 
 	if deletedCount > 0 {
-		log.Info().Msgf("Deleted %d applications", deletedCount)
+		log.Info().Msgf("🗑️ Deleted %d applications", deletedCount)
 	} else {
-		log.Info().Msgf("No applications with the label '%s' were found older than %d minutes", vars.ArgoCDApplicationLabelKey, minutes)
+		log.Info().Msgf("🤖 No applications with the label '%s' were found older than %d minutes", vars.ArgoCDApplicationLabelKey, minutes)
 	}
 
 	return nil

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -50,7 +50,7 @@ func NewClient(disableClientThrottling bool) (*Client, error) {
 			log.Debug().Err(err).Msg("Failed to create k8s client from service account")
 		} else {
 			config = c
-			log.Info().Msg("Using service account and environment variables to connect to cluster")
+			log.Info().Msg("📡 Using service account and environment variables to connect to cluster")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add support for `argocd-diff-preview/render` modes in filtering, and preserve identical resources from deduplication when either branch marks them with `render=always`.
- Strengthen unit coverage for render mode parsing and duplicate removal behavior, including ApplicationSet-focused cases for `always` and `changed`.