### PR TITLE
Fix | Prevent preview app deletion hooks

### DIFF
--- a/pkg/argoapplication/patching.go
+++ b/pkg/argoapplication/patching.go
@@ -229,17 +229,27 @@ func (a *ArgoResource) SetDestinationServerToLocal() error {
 	return nil
 }
 
-// RemoveArgoCDFinalizers removes only the resources-finalizer.argocd.argoproj.io finalizer
+// RemoveArgoCDFinalizers removes Argo CD finalizers that can block deleting preview applications
 func (a *ArgoResource) RemoveArgoCDFinalizers() error {
 	finalizers := a.Yaml.GetFinalizers()
 	if finalizers == nil {
 		return nil
 	}
 
-	// Filter out Argo CD finalizer in a single operation
+	argoCDFinalizers := map[string]bool{
+		"resources-finalizer.argocd.argoproj.io":            true,
+		"resources-finalizer.argocd.argoproj.io/background": true,
+		"resources-finalizer.argocd.argoproj.io/foreground": true,
+		"pre-delete-finalizer.argocd.argoproj.io":           true,
+		"pre-delete-finalizer.argocd.argoproj.io/cleanup":   true,
+		"post-delete-finalizer.argocd.argoproj.io":          true,
+		"post-delete-finalizer.argocd.argoproj.io/cleanup":  true,
+	}
+
+	// Filter out Argo CD finalizers in a single operation
 	filteredFinalizers := finalizers[:0]
 	for _, f := range finalizers {
-		if f != "resources-finalizer.argocd.argoproj.io" {
+		if !argoCDFinalizers[f] {
 			filteredFinalizers = append(filteredFinalizers, f)
 		}
 	}

--- a/pkg/argoapplication/patching_test.go
+++ b/pkg/argoapplication/patching_test.go
@@ -1151,6 +1151,12 @@ metadata:
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io/background
+    - resources-finalizer.argocd.argoproj.io/foreground
+    - pre-delete-finalizer.argocd.argoproj.io
+    - pre-delete-finalizer.argocd.argoproj.io/cleanup
+    - post-delete-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io/cleanup
     - some-other-finalizer
 spec:
   project: default

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -77,6 +77,18 @@ func (c *Client) DeleteArgoCDApplication(namespace string, name string) error {
 	}
 
 	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+	app, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get application %s before deletion: %w", name, err)
+	}
+
+	if len(app.GetFinalizers()) > 0 {
+		app.SetFinalizers(nil)
+		if _, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Update(context.Background(), app, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to remove finalizers from application %s before deletion: %w", name, err)
+		}
+	}
+
 	return c.clientSet.Resource(applicationRes).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }
 


### PR DESCRIPTION
## Summary
- Remove Argo CD deletion finalizers from preview Applications before applying and deleting them.
- Prevent pre-delete hooks from blocking cleanup of temporary preview Applications.

Fixes #414

## Testing
- go test ./pkg/argoapplication/... ./pkg/k8s/...