### PR TITLE
Fix for swallowing helm build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target-branch/
 temp/
 bin/
 .idea
+.opencode
+.claude

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -537,6 +537,8 @@ func buildManifestRequestForSource(
 				Namespace:          namespace,
 				ApplicationSource:  &primarySource,
 				HasMultipleSources: hasMultipleSources,
+				ProjectName:        "default",
+				ProjectSourceRepos: []string{"*"},
 			}
 			return request, "", nil, nil
 		}
@@ -559,6 +561,8 @@ func buildManifestRequestForSource(
 				Namespace:          namespace,
 				ApplicationSource:  &primarySource,
 				HasMultipleSources: hasMultipleSources,
+				ProjectName:        "default",
+				ProjectSourceRepos: []string{"*"},
 			}
 			return request, "", nil, nil
 		}
@@ -571,6 +575,8 @@ func buildManifestRequestForSource(
 			Namespace:          namespace,
 			ApplicationSource:  &primarySource,
 			HasMultipleSources: hasMultipleSources,
+			ProjectName:        "default",
+			ProjectSourceRepos: []string{"*"},
 		}
 		return request, branchFolder, nil, nil
 	}
@@ -607,6 +613,8 @@ func buildManifestRequestForSource(
 			ApplicationSource:  &primarySource,
 			HasMultipleSources: hasMultipleSources,
 			RefSources:         refSourcesMap,
+			ProjectName:        "default",
+			ProjectSourceRepos: []string{"*"},
 		}
 		return request, "", nil, nil
 	}
@@ -639,6 +647,8 @@ func buildManifestRequestForSource(
 			ApplicationSource:  &primarySource,
 			HasMultipleSources: hasMultipleSources,
 			RefSources:         refSourcesMap,
+			ProjectName:        "default",
+			ProjectSourceRepos: []string{"*"},
 		}
 		return request, "", nil, nil
 	}
@@ -720,6 +730,8 @@ func buildManifestRequestForSource(
 		Namespace:          namespace,
 		ApplicationSource:  &rewrittenSource,
 		HasMultipleSources: hasMultipleSources,
+		ProjectName:        "default",
+		ProjectSourceRepos: []string{"*"},
 	}
 	return request, tempDir, cleanup, nil
 }

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -104,6 +104,8 @@ spec:
 	assert.Empty(t, req.ApplicationSource.Chart, "should not have a Chart field")
 	assert.Equal(t, "production", req.Namespace)
 	assert.Nil(t, req.RefSources)
+	assert.Equal(t, "default", req.ProjectName, "project name must be set so repo-server does not mask helm dep errors as permission errors")
+	assert.Equal(t, []string{"*"}, req.ProjectSourceRepos, "all source repos must be permitted")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -144,6 +146,8 @@ spec:
 	assert.Equal(t, "cert-manager", req.ApplicationSource.Chart)
 	assert.Equal(t, "https://charts.jetstack.io", req.Repo.Repo)
 	assert.Nil(t, req.RefSources)
+	assert.Equal(t, "default", req.ProjectName, "project name must be set so repo-server does not mask helm dep errors as permission errors")
+	assert.Equal(t, []string{"*"}, req.ProjectSourceRepos, "all source repos must be permitted")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fix for #416

Note:
* Has unittest stating intent
* Not yet looked into integration tests

Using local build on the test setup described in #416, confirmed fixing the returned error

Was:

```
✨ Running v0.2.4 (2026-04-25T13:22:52Z) with:
...
❌ failed to render app local-chart-with-deps [t|examples/local-chart-with-deps/app.yaml]: repo server returned error for content source 0: failed to receive manifest response: rpc error: code = PermissionDenied desc = helm repos https://kubernetes.github.oopsie/ingress-nginx are not permitted in project ''
```

With this change:
```
✨ Running v0.2.4-8-gd3cab35 (2026-05-08T14:39:28Z) with:
...
❌ failed to render app local-chart-with-deps [t|examples/local-chart-with-deps/app.yaml]: repo server returned error for content source 0: failed to receive manifest response: rpc error: code = Unknown desc = error building helm chart dependencies: failed to add helm repository https://kubernetes.github.oopsie/ingress-nginx: failed to add repository: failed running helm: `helm repo add https:--kubernetes.github.oopsie-ingress-nginx https://kubernetes.github.oopsie/ingress-nginx` failed exit status 1: Error: looks like "https://kubernetes.github.oopsie/ingress-nginx" is not a valid chart repository or cannot be reached: Get "https://kubernetes.github.oopsie/ingress-nginx/index.yaml": dial tcp: lookup kubernetes.github.oopsie on 10.43.0.10:53: no such host
```