### PR TITLE
Fix | `argocd-diff-preview/render: always` now takes precedence over other selection filters

### DIFF
--- a/docs/application-selection.md
+++ b/docs/application-selection.md
@@ -249,10 +249,12 @@ The `argocd-diff-preview/render` annotation controls whether an Application or A
 | Value | Behavior |
 |-------|----------|
 | `changed` | Render only when the application changed or when its watch pattern matches changed files. This is the default behavior. |
-| `always` | Always render the application, even when the manifest is identical between the base and target branches. |
+| `always` | Always render the application or ApplicationSet. This takes precedence over selectors, file path regex filters, and changed-file detection. |
 | `never` | Never render the application. This replaces the deprecated `argocd-diff-preview/ignore: "true"` annotation. |
 
 This is useful for ApplicationSets where the ApplicationSet manifest itself may not change, but the generated Applications can still differ because generator input changed elsewhere.
+
+For ApplicationSets, the annotation only controls whether the ApplicationSet itself is rendered. It does not automatically force every generated Application to render. If a generated Application should also bypass selection filters, add `argocd-diff-preview/render: "always"` to the ApplicationSet template metadata annotations.
 
 ```yaml title="ApplicationSet" hl_lines="7"
 apiVersion: argoproj.io/v1alpha1

--- a/docs/application-selection.md
+++ b/docs/application-selection.md
@@ -256,16 +256,30 @@ This is useful for ApplicationSets where the ApplicationSet manifest itself may 
 
 For ApplicationSets, the annotation only controls whether the ApplicationSet itself is rendered. It does not automatically force every generated Application to render. If a generated Application should also bypass selection filters, add `argocd-diff-preview/render: "always"` to the ApplicationSet template metadata annotations.
 
-```yaml title="ApplicationSet" hl_lines="7"
+```yaml title="ApplicationSet" hl_lines="7 20"
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: my-appset
   namespace: argocd
-  annotations:
+  annotations: # Forces the ApplicationSet to always render, even if its own manifest doesn't change
     argocd-diff-preview/render: "always"
 spec:
-  # ...
+  generators:
+    - git:
+        repoURL: https://github.com/dag-andersen/argocd-diff-preview
+        revision: HEAD
+        directories:
+          - path: examples/helm/charts/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+      annotations:
+        # Forces every generated Application to always render, even if it doesn't change and doesn't match label selectors or file path regex filters
+        argocd-diff-preview/render: "always"
+    spec:
+      project: default
+      ...
 ```
 
 ---
@@ -280,9 +294,9 @@ Sometimes you need to permanently exclude specific applications from diff previe
 Add the `argocd-diff-preview/ignore: "true"` annotation to any Application or ApplicationSet manifest to skip it during rendering.
 
 !!! warning "Deprecated annotation"
-    The older `argocd-diff-preview/ignore: "true"` annotation is deprecated. It is still supported for backwards compatibility, but new configurations should use `argocd-diff-preview/render: "never"` instead.
+    This annotation is deprecated. It is still supported for backwards compatibility, but new configurations should use `argocd-diff-preview/render: "never"` instead.
 
-**Deprecated example: Ignoring an Application with `/ignore`**
+**Example: Ignoring an Application with `/ignore`**
 
 ```yaml title="Application" hl_lines="7"
 apiVersion: argoproj.io/v1alpha1

--- a/integration-test/branch-13/target-1/output.html
+++ b/integration-test/branch-13/target-1/output.html
@@ -172,12 +172,12 @@ ignore-annotation-example (examples/ignore-annotation/app.yaml)
 </div>
 
 <pre>_Skipped resources_: 
-- Applications: `6` (base) -> `9` (target)
+- Applications: `5` (base) -> `8` (target)
 - ApplicationSets: `3` (base) -> `1` (target)</pre>
 <br>
 
 <pre>_Stats_:
-[Applications: 37], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 39], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-13/target-1/output.md
+++ b/integration-test/branch-13/target-1/output.md
@@ -101,8 +101,8 @@ Added (1):
 </details>
 
 _Skipped resources_: 
-- Applications: `6` (base) -> `9` (target)
+- Applications: `5` (base) -> `8` (target)
 - ApplicationSets: `3` (base) -> `1` (target)
 
 _Stats_:
-[Applications: 37], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 39], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/branch-13/target-2/output.html
+++ b/integration-test/branch-13/target-2/output.html
@@ -172,8 +172,8 @@ label-selectors-example (examples/label-selectors/app.yaml)
 </div>
 
 <pre>_Skipped resources_: 
-- Applications: `13` (base) -> `12` (target)
-- ApplicationSets: `10` (base) -> `10` (target)</pre>
+- Applications: `14` (base) -> `13` (target)
+- ApplicationSets: `9` (base) -> `9` (target)</pre>
 <br>
 
 <pre>_Stats_:

--- a/integration-test/branch-13/target-2/output.html
+++ b/integration-test/branch-13/target-2/output.html
@@ -172,12 +172,12 @@ label-selectors-example (examples/label-selectors/app.yaml)
 </div>
 
 <pre>_Skipped resources_: 
-- Applications: `14` (base) -> `13` (target)
+- Applications: `13` (base) -> `12` (target)
 - ApplicationSets: `9` (base) -> `9` (target)</pre>
 <br>
 
 <pre>_Stats_:
-[Applications: 1], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+[Applications: 3], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
 </div>
 </body>
 </html>

--- a/integration-test/branch-13/target-2/output.md
+++ b/integration-test/branch-13/target-2/output.md
@@ -101,8 +101,8 @@ Added (1):
 </details>
 
 _Skipped resources_: 
-- Applications: `14` (base) -> `13` (target)
+- Applications: `13` (base) -> `12` (target)
 - ApplicationSets: `9` (base) -> `9` (target)
 
 _Stats_:
-[Applications: 1], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]
+[Applications: 3], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/branch-13/target-2/output.md
+++ b/integration-test/branch-13/target-2/output.md
@@ -101,8 +101,8 @@ Added (1):
 </details>
 
 _Skipped resources_: 
-- Applications: `13` (base) -> `12` (target)
-- ApplicationSets: `10` (base) -> `10` (target)
+- Applications: `14` (base) -> `13` (target)
+- ApplicationSets: `9` (base) -> `9` (target)
 
 _Stats_:
 [Applications: 1], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -189,11 +189,6 @@ func (a *ArgoResource) GetRenderMode() RenderMode {
 		}
 	}
 
-	// Legacy: treat ignore=true as never
-	if value, exists := annotations[annotationIgnore]; exists && value == "true" {
-		return RenderNever
-	}
-
 	return RenderChanged
 }
 

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -115,8 +115,17 @@ func ApplicationSelection(
 func (a *ArgoResource) Filter(
 	appSelectionOptions ApplicationSelectionOptions,
 ) bool {
+	// First check render mode annotation
+	switch a.GetRenderMode() {
+	case RenderNever:
+		log.Debug().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("%s is not selected because: application is ignored because render mode is '%s'", a.Kind.ShortName(), RenderNever)
+		return false
+	case RenderAlways:
+		log.Debug().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("%s is selected because: application is forced because render mode is '%s'", a.Kind.ShortName(), RenderAlways)
+		return true
+	}
 
-	// First check selected annotation
+	// Then check legacy ignore annotation
 	selected, reason := a.filterByIgnoreAnnotation()
 	if !selected {
 		log.Debug().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("%s is not selected because: %s", a.Kind.ShortName(), reason)
@@ -150,23 +159,9 @@ func (a *ArgoResource) filterByIgnoreAnnotation() (bool, string) {
 	// get annotations
 	annotations, found, err := unstructured.NestedStringMap(a.Yaml.Object, "metadata", "annotations")
 	if err != nil || !found || len(annotations) == 0 {
-		return true, "no 'argocd-diff-preview/ignore' or 'argocd-diff-preview/render' annotation found"
+		return true, "no 'argocd-diff-preview/ignore' annotation found"
 	}
 
-	// Check the new render annotation first (takes precedence)
-	if value, exists := annotations[annotationRender]; exists {
-		switch RenderMode(strings.ToLower(strings.TrimSpace(value))) {
-		case RenderNever:
-			return false, fmt.Sprintf("application is ignored because of '%s: %s'", annotationRender, value)
-		case RenderAlways, RenderChanged:
-			return true, fmt.Sprintf("application is selected because of '%s: %s'", annotationRender, value)
-		default:
-			log.Warn().Str(a.Kind.ShortName(), a.GetLongName()).Msgf("⚠️ Unknown value '%s' for annotation '%s'. Expected 'always', 'never', or 'changed'. Defaulting to 'changed'.", value, annotationRender)
-			return true, fmt.Sprintf("unknown render annotation value '%s', defaulting to 'changed'", value)
-		}
-	}
-
-	// Fall back to legacy ignore annotation
 	if value, exists := annotations[annotationIgnore]; exists && value == "true" {
 		return false, fmt.Sprintf("application is ignored because of '%s: %s'", annotationIgnore, value)
 	}
@@ -200,6 +195,20 @@ func (a *ArgoResource) GetRenderMode() RenderMode {
 	}
 
 	return RenderChanged
+}
+
+// SetRenderMode writes the render annotation for the resource.
+func (a *ArgoResource) SetRenderMode(mode RenderMode) {
+	if a.Yaml == nil {
+		return
+	}
+
+	annotations := a.Yaml.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[annotationRender] = string(mode)
+	a.Yaml.SetAnnotations(annotations)
 }
 
 // filterBySelectors checks if the application matches the given selectors

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -197,20 +197,6 @@ func (a *ArgoResource) GetRenderMode() RenderMode {
 	return RenderChanged
 }
 
-// SetRenderMode writes the render annotation for the resource.
-func (a *ArgoResource) SetRenderMode(mode RenderMode) {
-	if a.Yaml == nil {
-		return
-	}
-
-	annotations := a.Yaml.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[annotationRender] = string(mode)
-	a.Yaml.SetAnnotations(annotations)
-}
-
 // filterBySelectors checks if the application matches the given selectors
 func (a *ArgoResource) filterBySelectors(selectors []app_selector.Selector) (bool, string) {
 	// Early return if no YAML

--- a/pkg/argoapplication/filter_render_mode_test.go
+++ b/pkg/argoapplication/filter_render_mode_test.go
@@ -112,3 +112,18 @@ func TestGetRenderMode(t *testing.T) {
 		})
 	}
 }
+
+func TestSetRenderMode(t *testing.T) {
+	resource := &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name": "test-app",
+		},
+	}}}
+
+	resource.SetRenderMode(RenderAlways)
+
+	assert.Equal(t, RenderAlways, resource.GetRenderMode())
+	assert.Equal(t, map[string]string{
+		"argocd-diff-preview/render": "always",
+	}, resource.Yaml.GetAnnotations())
+}

--- a/pkg/argoapplication/filter_render_mode_test.go
+++ b/pkg/argoapplication/filter_render_mode_test.go
@@ -81,7 +81,7 @@ func TestGetRenderMode(t *testing.T) {
 			expectedMode: RenderChanged,
 		},
 		{
-			name: "legacy ignore true maps to render never",
+			name: "legacy ignore true does not set render mode",
 			resource: &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
 				"metadata": map[string]any{
 					"annotations": map[string]any{
@@ -89,7 +89,7 @@ func TestGetRenderMode(t *testing.T) {
 					},
 				},
 			}}},
-			expectedMode: RenderNever,
+			expectedMode: RenderChanged,
 		},
 		{
 			name: "render annotation takes precedence over legacy ignore",

--- a/pkg/argoapplication/filter_render_mode_test.go
+++ b/pkg/argoapplication/filter_render_mode_test.go
@@ -112,18 +112,3 @@ func TestGetRenderMode(t *testing.T) {
 		})
 	}
 }
-
-func TestSetRenderMode(t *testing.T) {
-	resource := &ArgoResource{Yaml: &unstructured.Unstructured{Object: map[string]any{
-		"metadata": map[string]any{
-			"name": "test-app",
-		},
-	}}}
-
-	resource.SetRenderMode(RenderAlways)
-
-	assert.Equal(t, RenderAlways, resource.GetRenderMode())
-	assert.Equal(t, map[string]string{
-		"argocd-diff-preview/render": "always",
-	}, resource.Yaml.GetAnnotations())
-}

--- a/pkg/argoapplication/filter_test.go
+++ b/pkg/argoapplication/filter_test.go
@@ -896,6 +896,61 @@ metadata:
 			watchIfNoWatchPatternFound: false,
 			want:                       true,
 		},
+		{
+			name: "render always bypasses non-matching selector",
+			yaml: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  labels:
+    team: other-team
+  annotations:
+    argocd-diff-preview/render: always`,
+			selectors: []app_selector.Selector{
+				{Key: "team", Value: "your-team", Operator: app_selector.Eq},
+			},
+			filesChanged:               []string{},
+			ignoreInvalidWatchPattern:  false,
+			watchIfNoWatchPatternFound: false,
+			want:                       true,
+		},
+		{
+			name: "render always bypasses non-matching watch pattern",
+			yaml: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  annotations:
+    argocd-diff-preview/render: always
+    argocd-diff-preview/watch-pattern: '.*\.yaml$'`,
+			selectors:                  []app_selector.Selector{},
+			filesChanged:               []string{"test.txt"},
+			ignoreInvalidWatchPattern:  false,
+			watchIfNoWatchPatternFound: false,
+			want:                       true,
+		},
+		{
+			name: "render always bypasses selector and watch pattern filters",
+			yaml: `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  labels:
+    team: other-team
+  annotations:
+    argocd-diff-preview/render: always
+    argocd-diff-preview/watch-pattern: '.*\.yaml$'`,
+			selectors: []app_selector.Selector{
+				{Key: "team", Value: "your-team", Operator: app_selector.Eq},
+			},
+			filesChanged:               []string{"test.txt"},
+			ignoreInvalidWatchPattern:  false,
+			watchIfNoWatchPatternFound: false,
+			want:                       true,
+		},
 		// Integration tests for WatchIfNoWatchPatternFound behavior
 		{
 			name: "no watch pattern with WatchIfNoWatchPatternFound=true should include app",


### PR DESCRIPTION
## Summary
- Make `argocd-diff-preview/render: always` take precedence over selectors and file-change filtering.
- Keep generated Applications independent from an ApplicationSet-level render annotation.
- Update branch-13 target-2 integration output to reflect the changed skipped-resource counts.

## Testing
- `go test ./pkg/argoapplication/...`
- `TEST_CASE=\"branch-13/target-1\" go test -v -timeout 20m -run TestSingleCase -update ./...`
- `TEST_CASE=\"branch-13/target-2\" go test -v -timeout 20m -run TestSingleCase -update ./...`