### PR TITLE
Fix | Embed Argo CD default overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-${TARGETARCH}
 # Copy source code - only what's needed
 COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
+COPY argocd-config/ ./argocd-config/
 
 # Build arguments for version information (declared late to maximize cache hits)
 ARG VERSION=dev
@@ -43,7 +44,7 @@ COPY --from=build /argocd-diff-preview/argocd-diff-preview .
 COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
 
 # copy argocd helm chart values
-COPY ./argocd-config ./argocd-config
+COPY ./argocd-config/*.yaml ./argocd-config/
 
 # set the startup command to run your binary
 ENTRYPOINT ["./argocd-diff-preview"]

--- a/argocd-config/config.go
+++ b/argocd-config/config.go
@@ -1,0 +1,6 @@
+package argocdconfig
+
+import _ "embed"
+
+//go:embed values-override.yaml
+var ValuesOverride []byte

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -35,6 +35,7 @@ const (
 	defaultMaxDiffLen = "65536"
 	defaultTitle      = "Argo CD Diff Preview"
 	argocdNamespace   = "argocd-diff-preview"
+	clusterName       = "argocd-diff-preview"
 )
 
 // TestCase defines a single integration test case
@@ -465,7 +466,7 @@ func kindClusterExists() bool {
 		return false
 	}
 	// Check if our cluster name is in the list
-	return slices.Contains(strings.Split(strings.TrimSpace(string(output)), "\n"), "argocd-diff-preview")
+	return slices.Contains(strings.Split(strings.TrimSpace(string(output)), "\n"), clusterName)
 }
 
 // clusterHasArgocdClusterRoles checks if the cluster has ArgoCD cluster roles installed.
@@ -540,7 +541,7 @@ func orderTestCases(cases []TestCase) []TestCase {
 
 // deleteKindCluster deletes the kind cluster used for testing
 func deleteKindCluster() error {
-	cmd := exec.Command("kind", "delete", "cluster", "--name", "argocd-diff-preview")
+	cmd := exec.Command("kind", "delete", "cluster", "--name", clusterName)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -734,21 +735,40 @@ func buildDockerImage() error {
 }
 
 // runWithGoBinary executes the test using the Go binary
-// Runs from repo root directory so it can find argocd-config/
+// Runs from a subdirectory so the binary does not accidentally depend on
+// ./argocd-config from the repository root. Tests that need custom Argo CD
+// values pass --argocd-config-dir explicitly.
 func runWithGoBinary(tc TestCase, createCluster bool) error {
-	args := buildArgs(tc, createCluster)
-
 	// Get repo root (parent of integration-test/)
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		return fmt.Errorf("failed to get repo root: %w", err)
 	}
 
+	runDir := filepath.Join(repoRoot, "temp", "go-binary-run")
+	if err := os.RemoveAll(runDir); err != nil {
+		return fmt.Errorf("failed to clean go binary run dir: %w", err)
+	}
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		return fmt.Errorf("failed to create go binary run dir: %w", err)
+	}
+	if err := copyDir(filepath.Join(repoRoot, "base-branch"), filepath.Join(runDir, "base-branch")); err != nil {
+		return fmt.Errorf("failed to copy base branch into go binary run dir: %w", err)
+	}
+	if err := copyDir(filepath.Join(repoRoot, "target-branch"), filepath.Join(runDir, "target-branch")); err != nil {
+		return fmt.Errorf("failed to copy target branch into go binary run dir: %w", err)
+	}
+	if err := copyDir(filepath.Join(repoRoot, "kind-config"), filepath.Join(runDir, "kind-config")); err != nil {
+		return fmt.Errorf("failed to copy kind config into go binary run dir: %w", err)
+	}
+
+	args := buildArgs(tc, createCluster, repoRoot)
+
 	// Binary path is relative to repo root
 	absBinaryPath := filepath.Join(repoRoot, *binaryPath)
 
 	cmd := exec.Command(absBinaryPath, args...)
-	cmd.Dir = repoRoot // Run from repo root so it finds argocd-config/
+	cmd.Dir = runDir
 
 	// Try to get TTY for real-time output (Go test captures stdout/stderr)
 	if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
@@ -922,8 +942,9 @@ func runWithDocker(tc TestCase, createCluster bool) error {
 	return cmd.Run()
 }
 
-// buildArgs constructs command line arguments for the Go binary
-func buildArgs(tc TestCase, createCluster bool) []string {
+// buildArgs constructs command line arguments for the Go binary.
+// Paths are absolute because the binary runs from a dedicated subdirectory.
+func buildArgs(tc TestCase, createCluster bool, repoRoot string) []string {
 	args := []string{
 		"--base-branch", tc.BaseBranch,
 		"--target-branch", tc.TargetBranch,
@@ -933,6 +954,8 @@ func buildArgs(tc TestCase, createCluster bool) []string {
 		"--line-count", getLineCount(tc),
 		"--max-diff-length", getMaxDiffLength(tc),
 		"--title", getTitle(tc),
+		"--output-folder", filepath.Join(repoRoot, "output"),
+		"--secrets-folder", filepath.Join(repoRoot, "secrets"),
 		"--keep-cluster-alive",
 		"--disable-client-throttling",
 	}
@@ -1004,9 +1027,9 @@ func buildArgs(tc TestCase, createCluster bool) []string {
 	// If ArgocdConfigDir is explicitly set, use that directory instead.
 	// This avoids mutating the shared argocd-config/values.yaml on disk.
 	if tc.ArgocdConfigDir != "" {
-		args = append(args, "--argocd-config-dir", fmt.Sprintf("./integration-test/%s", tc.ArgocdConfigDir))
+		args = append(args, "--argocd-config-dir", filepath.Join(repoRoot, "integration-test", tc.ArgocdConfigDir))
 	} else if tc.DisableClusterRoles == "true" || isAPIMode(tc) {
-		args = append(args, "--argocd-config-dir", "./integration-test/no-cluster-roles")
+		args = append(args, "--argocd-config-dir", filepath.Join(repoRoot, "integration-test", "no-cluster-roles"))
 	}
 
 	return args

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -578,8 +578,8 @@ func runTestCase(t *testing.T, tc TestCase, createCluster bool) {
 	if err := os.MkdirAll(runDirs.Root, 0755); err != nil {
 		t.Fatalf("Failed to create run dir: %v", err)
 	}
-	if err := os.MkdirAll(runDirs.Secrets, 0755); err != nil {
-		t.Fatalf("Failed to create secrets dir: %v", err)
+	if err := copyDir(filepath.Join(repoRoot, "integration-test", "secrets"), runDirs.Secrets); err != nil {
+		t.Fatalf("Failed to copy secrets fixture: %v", err)
 	}
 	if err := os.MkdirAll(runDirs.Temp, 0755); err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -970,7 +970,6 @@ func buildArgs(tc TestCase, createCluster bool, runDirs RunDirs, repoRoot string
 		"--line-count", getLineCount(tc),
 		"--max-diff-length", getMaxDiffLength(tc),
 		"--title", getTitle(tc),
-		"--secrets-folder", runDirs.Secrets,
 		"--keep-cluster-alive",
 		"--disable-client-throttling",
 	}

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -68,6 +68,16 @@ type TestCase struct {
 	ExpectFailure              bool   // If true, the test is expected to fail
 }
 
+type RunDirs struct {
+	Root         string
+	BaseBranch   string
+	TargetBranch string
+	Output       string
+	Secrets      string
+	Temp         string
+	KindConfig   string
+}
+
 // testCases defines all integration test cases matching the Makefile
 var testCases = []TestCase{
 	{
@@ -549,53 +559,67 @@ func deleteKindCluster() error {
 
 // runTestCase executes a single test case
 // createCluster indicates whether this test should create a new cluster (true for first test)
-// Both Go binary and Docker run from repo root for consistency
+// Both Go binary and Docker use the same isolated run directory so neither mode
+// accidentally depends on files from the repository root.
 func runTestCase(t *testing.T, tc TestCase, createCluster bool) {
 	// Force cluster creation if the test case requires it (e.g., for testing role changes)
 	if tc.CreateCluster == "true" {
 		createCluster = true
 	}
 
-	// All directories are at repo root (parent of integration-test/)
-	baseBranchDir := "../base-branch"
-	targetBranchDir := "../target-branch"
-	outputDir := "../output"
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("Failed to get repo root: %v", err)
+	}
+	runDirs := newRunDirs(repoRoot)
 
 	// Clean up from previous runs
-	cleanup(baseBranchDir, targetBranchDir, outputDir)
+	cleanup(runDirs.Root)
+	if err := os.MkdirAll(runDirs.Root, 0755); err != nil {
+		t.Fatalf("Failed to create run dir: %v", err)
+	}
+	if err := os.MkdirAll(runDirs.Secrets, 0755); err != nil {
+		t.Fatalf("Failed to create secrets dir: %v", err)
+	}
+	if err := os.MkdirAll(runDirs.Temp, 0755); err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	if err := copyDir(filepath.Join(repoRoot, "kind-config"), runDirs.KindConfig); err != nil {
+		t.Fatalf("Failed to copy kind config: %v", err)
+	}
 
-	// Clone the repositories to repo root
-	if err := cloneBranch(tc.BaseBranch, baseBranchDir); err != nil {
+	// Clone the repositories to the run directory
+	if err := cloneBranch(tc.BaseBranch, runDirs.BaseBranch); err != nil {
 		t.Fatalf("Failed to clone base branch: %v", err)
 	}
-	if err := cloneBranch(tc.TargetBranch, targetBranchDir); err != nil {
+	if err := cloneBranch(tc.TargetBranch, runDirs.TargetBranch); err != nil {
 		t.Fatalf("Failed to clone target branch: %v", err)
 	}
 
 	// Run the tool
-	var err error
+	var runErr error
 	if *useDocker {
-		err = runWithDocker(tc, createCluster)
+		runErr = runWithDocker(tc, createCluster, runDirs)
 	} else {
-		err = runWithGoBinary(tc, createCluster)
+		runErr = runWithGoBinary(tc, createCluster, runDirs, repoRoot)
 	}
 
 	// Handle expected failures
 	if tc.ExpectFailure {
-		if err != nil {
-			t.Logf("Test failed as expected: %v", err)
+		if runErr != nil {
+			t.Logf("Test failed as expected: %v", runErr)
 			return // Success - we expected it to fail
 		}
 		t.Fatalf("Expected test to fail, but it succeeded")
 	}
 
-	if err != nil {
-		t.Fatalf("Failed to run tool: %v", err)
+	if runErr != nil {
+		t.Fatalf("Failed to run tool: %v", runErr)
 	}
 
 	// Check if output files were created (at repo root)
-	mdPath := filepath.Join(outputDir, "diff.md")
-	htmlPath := filepath.Join(outputDir, "diff.html")
+	mdPath := filepath.Join(runDirs.Output, "diff.md")
+	htmlPath := filepath.Join(runDirs.Output, "diff.html")
 
 	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
 		t.Fatalf("Tool completed but did not create output file: %s (this may indicate the tool exited early without generating output)", mdPath)
@@ -606,7 +630,20 @@ func runTestCase(t *testing.T, tc TestCase, createCluster bool) {
 
 	// Compare outputs
 	expectedDir := getExpectedDir(tc)
-	compareOutput(t, tc, expectedDir, outputDir)
+	compareOutput(t, tc, expectedDir, runDirs.Output)
+}
+
+func newRunDirs(repoRoot string) RunDirs {
+	root := filepath.Join(repoRoot, "integration-test", "temp", "integration-run")
+	return RunDirs{
+		Root:         root,
+		BaseBranch:   filepath.Join(root, "base-branch"),
+		TargetBranch: filepath.Join(root, "target-branch"),
+		Output:       filepath.Join(root, "output"),
+		Secrets:      filepath.Join(root, "secrets"),
+		Temp:         filepath.Join(root, "temp"),
+		KindConfig:   filepath.Join(root, "kind-config"),
+	}
 }
 
 // cleanup removes directories from previous test runs
@@ -738,37 +775,14 @@ func buildDockerImage() error {
 // Runs from a subdirectory so the binary does not accidentally depend on
 // ./argocd-config from the repository root. Tests that need custom Argo CD
 // values pass --argocd-config-dir explicitly.
-func runWithGoBinary(tc TestCase, createCluster bool) error {
-	// Get repo root (parent of integration-test/)
-	repoRoot, err := filepath.Abs("..")
-	if err != nil {
-		return fmt.Errorf("failed to get repo root: %w", err)
-	}
-
-	runDir := filepath.Join(repoRoot, "temp", "go-binary-run")
-	if err := os.RemoveAll(runDir); err != nil {
-		return fmt.Errorf("failed to clean go binary run dir: %w", err)
-	}
-	if err := os.MkdirAll(runDir, 0755); err != nil {
-		return fmt.Errorf("failed to create go binary run dir: %w", err)
-	}
-	if err := copyDir(filepath.Join(repoRoot, "base-branch"), filepath.Join(runDir, "base-branch")); err != nil {
-		return fmt.Errorf("failed to copy base branch into go binary run dir: %w", err)
-	}
-	if err := copyDir(filepath.Join(repoRoot, "target-branch"), filepath.Join(runDir, "target-branch")); err != nil {
-		return fmt.Errorf("failed to copy target branch into go binary run dir: %w", err)
-	}
-	if err := copyDir(filepath.Join(repoRoot, "kind-config"), filepath.Join(runDir, "kind-config")); err != nil {
-		return fmt.Errorf("failed to copy kind config into go binary run dir: %w", err)
-	}
-
-	args := buildArgs(tc, createCluster, repoRoot)
+func runWithGoBinary(tc TestCase, createCluster bool, runDirs RunDirs, repoRoot string) error {
+	args := buildArgs(tc, createCluster, runDirs, repoRoot)
 
 	// Binary path is relative to repo root
 	absBinaryPath := filepath.Join(repoRoot, *binaryPath)
 
 	cmd := exec.Command(absBinaryPath, args...)
-	cmd.Dir = runDir
+	cmd.Dir = runDirs.Root
 
 	// Try to get TTY for real-time output (Go test captures stdout/stderr)
 	if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
@@ -808,7 +822,7 @@ func getDockerAPIVersion() string {
 
 // runWithDocker executes the test using Docker
 // Mounts volumes from repo root directory
-func runWithDocker(tc TestCase, createCluster bool) error {
+func runWithDocker(tc TestCase, createCluster bool, runDirs RunDirs) error {
 	// Remove any existing container (ignore error - container may not exist)
 	_ = exec.Command("docker", "rm", "-f", "argocd-diff-preview").Run()
 
@@ -833,12 +847,12 @@ func runWithDocker(tc TestCase, createCluster bool) error {
 		"--name=argocd-diff-preview",
 		"-v", fmt.Sprintf("%s/.kube:/root/.kube", homeDir),
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
-		"-v", fmt.Sprintf("%s/base-branch:/base-branch", repoRoot),
-		"-v", fmt.Sprintf("%s/target-branch:/target-branch", repoRoot),
-		"-v", fmt.Sprintf("%s/output:/output", repoRoot),
-		"-v", fmt.Sprintf("%s/secrets:/secrets", repoRoot),
-		"-v", fmt.Sprintf("%s/temp:/temp", repoRoot),
-		"-v", fmt.Sprintf("%s/kind-config:/kind-config", repoRoot),
+		"-v", fmt.Sprintf("%s:/base-branch", runDirs.BaseBranch),
+		"-v", fmt.Sprintf("%s:/target-branch", runDirs.TargetBranch),
+		"-v", fmt.Sprintf("%s:/output", runDirs.Output),
+		"-v", fmt.Sprintf("%s:/secrets", runDirs.Secrets),
+		"-v", fmt.Sprintf("%s:/temp", runDirs.Temp),
+		"-v", fmt.Sprintf("%s:/kind-config", runDirs.KindConfig),
 	}
 
 	// When using a custom ArgoCD config directory, mount the entire directory.
@@ -928,6 +942,7 @@ func runWithDocker(tc TestCase, createCluster bool) error {
 	args = append(args, *dockerImage)
 
 	cmd := exec.Command("docker", args...)
+	cmd.Dir = runDirs.Root
 
 	// Try to get TTY for real-time output (Go test captures stdout/stderr)
 	if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
@@ -943,8 +958,9 @@ func runWithDocker(tc TestCase, createCluster bool) error {
 }
 
 // buildArgs constructs command line arguments for the Go binary.
-// Paths are absolute because the binary runs from a dedicated subdirectory.
-func buildArgs(tc TestCase, createCluster bool, repoRoot string) []string {
+// The binary runs from runDirs.Root, so default branch and output folders are
+// resolved relative to that isolated integration workspace.
+func buildArgs(tc TestCase, createCluster bool, runDirs RunDirs, repoRoot string) []string {
 	args := []string{
 		"--base-branch", tc.BaseBranch,
 		"--target-branch", tc.TargetBranch,
@@ -954,8 +970,7 @@ func buildArgs(tc TestCase, createCluster bool, repoRoot string) []string {
 		"--line-count", getLineCount(tc),
 		"--max-diff-length", getMaxDiffLength(tc),
 		"--title", getTitle(tc),
-		"--output-folder", filepath.Join(repoRoot, "output"),
-		"--secrets-folder", filepath.Join(repoRoot, "secrets"),
+		"--secrets-folder", runDirs.Secrets,
 		"--keep-cluster-alive",
 		"--disable-client-throttling",
 	}

--- a/integration-test/secrets/test-repository-secret.yaml
+++ b/integration-test/secrets/test-repository-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: integration-test-repository-secret
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: https://github.com/dag-andersen/argocd-diff-preview.git

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -392,6 +392,10 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 		}
 	}
 
+	// Values are merged in this order. Later files override earlier files:
+	// 1. user values.yaml
+	// 2. embedded argocd-diff-preview values-override.yaml
+	// 3. user values-override.yaml
 	valuesFiles := []string{}
 	if foundUserValues {
 		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, valuesFileName))

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -410,11 +410,11 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 	return valuesFiles, nil
 }
 
-func (a *ArgoCDInstallation) mergeValues(settings *cli.EnvSettings, valuesFiles []string) (map[string]interface{}, error) {
-	mergedValues := map[string]interface{}{}
+func (a *ArgoCDInstallation) mergeValues(settings *cli.EnvSettings, valuesFiles []string) (map[string]any, error) {
+	mergedValues := map[string]any{}
 
 	for _, valuesFile := range valuesFiles {
-		var currentValues map[string]interface{}
+		var currentValues map[string]any
 		var err error
 
 		if valuesFile == embeddedValuesOverrideLabel {
@@ -433,27 +433,27 @@ func (a *ArgoCDInstallation) mergeValues(settings *cli.EnvSettings, valuesFiles 
 	return mergedValues, nil
 }
 
-func loadEmbeddedValuesOverride() (map[string]interface{}, error) {
-	var chartValues map[string]interface{}
+func loadEmbeddedValuesOverride() (map[string]any, error) {
+	var chartValues map[string]any
 	if err := yaml.Unmarshal(argocdconfig.ValuesOverride, &chartValues); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal embedded values override: %w", err)
 	}
 
 	if chartValues == nil {
-		chartValues = map[string]interface{}{}
+		chartValues = map[string]any{}
 	}
 
 	return chartValues, nil
 }
 
-func mergeMaps(base, override map[string]interface{}) map[string]interface{} {
+func mergeMaps(base, override map[string]any) map[string]any {
 	if base == nil {
-		base = map[string]interface{}{}
+		base = map[string]any{}
 	}
 
 	for key, overrideValue := range override {
-		if overrideMap, ok := overrideValue.(map[string]interface{}); ok {
-			if baseMap, ok := base[key].(map[string]interface{}); ok {
+		if overrideMap, ok := overrideValue.(map[string]any); ok {
+			if baseMap, ok := base[key].(map[string]any); ok {
 				base[key] = mergeMaps(baseMap, overrideMap)
 				continue
 			}

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -377,7 +377,7 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 		return nil, fmt.Errorf("failed to read folder: %w", err)
 	}
 
-	var foundValues bool
+	var foundUserValues bool
 	var foundUserValuesOverride bool
 
 	for _, file := range files {
@@ -385,7 +385,7 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 
 		name := file.Name()
 		if name == valuesFileName {
-			foundValues = true
+			foundUserValues = true
 		}
 		if name == valuesOverrideFileName {
 			foundUserValuesOverride = true
@@ -393,7 +393,7 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 	}
 
 	valuesFiles := []string{}
-	if foundValues {
+	if foundUserValues {
 		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, valuesFileName))
 	}
 

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	argocdconfig "github.com/dag-andersen/argocd-diff-preview/argocd-config"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/k8s"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/vars"
 	"github.com/rs/zerolog/log"
@@ -24,6 +25,12 @@ import (
 )
 
 const ociScheme = "oci://"
+
+const (
+	valuesFileName              = "values.yaml"
+	valuesOverrideFileName      = "values-override.yaml"
+	embeddedValuesOverrideLabel = "embedded values-override.yaml"
+)
 
 func isOCIChartURL(url string) bool {
 	return strings.HasPrefix(strings.TrimSpace(url), ociScheme)
@@ -195,11 +202,7 @@ func (a *ArgoCDInstallation) installWithHelm() error {
 		return fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	// Load values from files
-	valueOpts := &values.Options{
-		ValueFiles: valuesFiles,
-	}
-	chartValues, err := valueOpts.MergeValues(getter.All(settings))
+	chartValues, err := a.mergeValues(settings, valuesFiles)
 	if err != nil {
 		return fmt.Errorf("failed to merge values: %w", err)
 	}
@@ -367,33 +370,95 @@ func (a *ArgoCDInstallation) findValuesFiles() ([]string, error) {
 
 	files, err := os.ReadDir(a.ConfigPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.Info().Msgf("📂 Folder '%s' doesn't exist. Installing Argo CD Helm Chart with embedded argocd-diff-preview overrides", a.ConfigPath)
+			return []string{embeddedValuesOverrideLabel}, nil
+		}
 		return nil, fmt.Errorf("failed to read folder: %w", err)
 	}
 
 	var foundValues bool
-	var foundValuesOverride bool
+	var foundUserValuesOverride bool
 
 	for _, file := range files {
 		log.Debug().Msgf("- 📄 %s", file.Name())
 
 		name := file.Name()
-		if name == "values.yaml" {
+		if name == valuesFileName {
 			foundValues = true
 		}
-		if name == "values-override.yaml" {
-			foundValuesOverride = true
+		if name == valuesOverrideFileName {
+			foundUserValuesOverride = true
 		}
 	}
 
 	valuesFiles := []string{}
 	if foundValues {
-		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, "values.yaml"))
+		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, valuesFileName))
 	}
-	if foundValuesOverride {
-		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, "values-override.yaml"))
+
+	valuesFiles = append(valuesFiles, embeddedValuesOverrideLabel)
+
+	if foundUserValuesOverride {
+		valuesFiles = append(valuesFiles, filepath.Join(a.ConfigPath, valuesOverrideFileName))
 	}
 
 	return valuesFiles, nil
+}
+
+func (a *ArgoCDInstallation) mergeValues(settings *cli.EnvSettings, valuesFiles []string) (map[string]interface{}, error) {
+	mergedValues := map[string]interface{}{}
+
+	for _, valuesFile := range valuesFiles {
+		var currentValues map[string]interface{}
+		var err error
+
+		if valuesFile == embeddedValuesOverrideLabel {
+			currentValues, err = loadEmbeddedValuesOverride()
+		} else {
+			valueOpts := &values.Options{ValueFiles: []string{valuesFile}}
+			currentValues, err = valueOpts.MergeValues(getter.All(settings))
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		mergedValues = mergeMaps(mergedValues, currentValues)
+	}
+
+	return mergedValues, nil
+}
+
+func loadEmbeddedValuesOverride() (map[string]interface{}, error) {
+	var chartValues map[string]interface{}
+	if err := yaml.Unmarshal(argocdconfig.ValuesOverride, &chartValues); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal embedded values override: %w", err)
+	}
+
+	if chartValues == nil {
+		chartValues = map[string]interface{}{}
+	}
+
+	return chartValues, nil
+}
+
+func mergeMaps(base, override map[string]interface{}) map[string]interface{} {
+	if base == nil {
+		base = map[string]interface{}{}
+	}
+
+	for key, overrideValue := range override {
+		if overrideMap, ok := overrideValue.(map[string]interface{}); ok {
+			if baseMap, ok := base[key].(map[string]interface{}); ok {
+				base[key] = mergeMaps(baseMap, overrideMap)
+				continue
+			}
+		}
+
+		base[key] = overrideValue
+	}
+
+	return base
 }
 
 // OnlyLogin performs only the login step without installing ArgoCD

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -1,8 +1,15 @@
 package argocd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	argocdconfig "github.com/dag-andersen/argocd-diff-preview/argocd-config"
+	"helm.sh/helm/v3/pkg/cli"
 )
 
 func TestIsOCIChartURL(t *testing.T) {
@@ -90,5 +97,149 @@ func TestInstallWithHelm_OCIRequiresExplicitVersion(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestFindValuesFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		wantLabels []string
+	}{
+		{
+			name:       "empty config dir uses embedded override",
+			files:      map[string]string{},
+			wantLabels: []string{embeddedValuesOverrideLabel},
+		},
+		{
+			name: "values file loads before embedded override",
+			files: map[string]string{
+				valuesFileName: "configs: {}\n",
+			},
+			wantLabels: []string{valuesFileName, embeddedValuesOverrideLabel},
+		},
+		{
+			name: "user override loads after embedded override",
+			files: map[string]string{
+				valuesFileName:         "configs: {}\n",
+				valuesOverrideFileName: "dex:\n  enabled: true\n",
+			},
+			wantLabels: []string{valuesFileName, embeddedValuesOverrideLabel, valuesOverrideFileName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := t.TempDir()
+			for fileName, contents := range tt.files {
+				if err := os.WriteFile(filepath.Join(configPath, fileName), []byte(contents), 0o644); err != nil {
+					t.Fatalf("failed to write %s: %v", fileName, err)
+				}
+			}
+
+			a := &ArgoCDInstallation{ConfigPath: configPath}
+			got, err := a.findValuesFiles()
+			if err != nil {
+				t.Fatalf("findValuesFiles returned error: %v", err)
+			}
+
+			gotLabels := make([]string, 0, len(got))
+			for _, valueFile := range got {
+				if valueFile == embeddedValuesOverrideLabel {
+					gotLabels = append(gotLabels, valueFile)
+					continue
+				}
+				gotLabels = append(gotLabels, filepath.Base(valueFile))
+			}
+
+			if !reflect.DeepEqual(gotLabels, tt.wantLabels) {
+				t.Fatalf("findValuesFiles labels = %#v, want %#v", gotLabels, tt.wantLabels)
+			}
+		})
+	}
+}
+
+func TestFindValuesFiles_MissingConfigDirUsesEmbeddedOverride(t *testing.T) {
+	a := &ArgoCDInstallation{ConfigPath: filepath.Join(t.TempDir(), "missing")}
+
+	got, err := a.findValuesFiles()
+	if err != nil {
+		t.Fatalf("findValuesFiles returned error: %v", err)
+	}
+
+	want := []string{embeddedValuesOverrideLabel}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("findValuesFiles = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeValues_UserOverrideWinsOverEmbeddedOverride(t *testing.T) {
+	configPath := t.TempDir()
+
+	valuesContent := []byte(`configs:
+  cm:
+    kustomize.buildOptions: --enable-helm
+`)
+	if err := os.WriteFile(filepath.Join(configPath, valuesFileName), valuesContent, 0o644); err != nil {
+		t.Fatalf("failed to write values file: %v", err)
+	}
+
+	valuesOverrideContent := []byte(`dex:
+  enabled: true
+applicationSet:
+  replicas: 2
+configs:
+  params:
+    hydrator.enabled: "true"
+`)
+	if err := os.WriteFile(filepath.Join(configPath, valuesOverrideFileName), valuesOverrideContent, 0o644); err != nil {
+		t.Fatalf("failed to write override values file: %v", err)
+	}
+
+	a := &ArgoCDInstallation{ConfigPath: configPath}
+	valuesFiles, err := a.findValuesFiles()
+	if err != nil {
+		t.Fatalf("findValuesFiles returned error: %v", err)
+	}
+
+	got, err := a.mergeValues(cli.New(), valuesFiles)
+	if err != nil {
+		t.Fatalf("mergeValues returned error: %v", err)
+	}
+
+	assertNestedValue(t, got, true, "dex", "enabled")
+	assertNestedValue(t, got, int64(2), "applicationSet", "replicas")
+	assertNestedValue(t, got, "true", "configs", "params", "hydrator.enabled")
+	assertNestedValue(t, got, "--enable-helm", "configs", "cm", "kustomize.buildOptions")
+}
+
+func TestEmbeddedValuesOverrideMatchesDefaultConfig(t *testing.T) {
+	repoValues, err := os.ReadFile(filepath.Join("..", "..", "argocd-config", valuesOverrideFileName))
+	if err != nil {
+		t.Fatalf("failed to read repository values override: %v", err)
+	}
+
+	if string(argocdconfig.ValuesOverride) != string(repoValues) {
+		t.Fatal("embedded values override differs from argocd-config/values-override.yaml")
+	}
+}
+
+func assertNestedValue(t *testing.T, values map[string]interface{}, want interface{}, path ...string) {
+	t.Helper()
+
+	var current interface{} = values
+	for _, key := range path {
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			t.Fatalf("path %v hit non-map value %#v", path, current)
+		}
+		current = currentMap[key]
+	}
+
+	if !reflect.DeepEqual(current, want) {
+		if fmt.Sprint(current) == fmt.Sprint(want) {
+			return
+		}
+		t.Fatalf("path %v = %#v, want %#v", path, current, want)
 	}
 }

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -224,12 +224,12 @@ func TestEmbeddedValuesOverrideMatchesDefaultConfig(t *testing.T) {
 	}
 }
 
-func assertNestedValue(t *testing.T, values map[string]interface{}, want interface{}, path ...string) {
+func assertNestedValue(t *testing.T, values map[string]any, want any, path ...string) {
 	t.Helper()
 
-	var current interface{} = values
+	var current any = values
 	for _, key := range path {
-		currentMap, ok := current.(map[string]interface{})
+		currentMap, ok := current.(map[string]any)
 		if !ok {
 			t.Fatalf("path %v hit non-map value %#v", path, current)
 		}


### PR DESCRIPTION
## Summary
- Embed the default Argo CD `values-override.yaml` so binary runs use the same built-in overrides as Docker runs.
- Keep user `values-override.yaml` last in the merge order so user overrides still win.
- Update the Docker build to include the config package at build time while only copying YAML files into the final image.
- Run Go binary and Docker integration tests from an isolated workspace under `integration-test/temp/integration-run`, including copied `kind-config` and secrets fixtures.