### PR TITLE
feat: Add --fail-on-invalid-generated-applications strict mode flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,12 +85,13 @@ func run(cfg *Config) error {
 	searchIsLimited := len(selectors) > 0 || len(filesChanged) > 0 || fileRegex != nil
 
 	appSelectionOptions := argoapplication.ApplicationSelectionOptions{
-		Selector:                           selectors,
-		FileRegex:                          fileRegex,
-		FilesChanged:                       filesChanged,
-		IgnoreInvalidWatchPattern:          cfg.IgnoreInvalidWatchPattern,
-		WatchIfNoWatchPatternFound:         cfg.WatchIfNoWatchPatternFound,
-		FailOnInvalidGeneratedApplications: cfg.FailOnInvalidGeneratedApplications,
+		Selector:                             selectors,
+		FileRegex:                            fileRegex,
+		FilesChanged:                         filesChanged,
+		IgnoreInvalidWatchPattern:            cfg.IgnoreInvalidWatchPattern,
+		WatchIfNoWatchPatternFound:           cfg.WatchIfNoWatchPatternFound,
+		FailOnInvalidGeneratedApplications:   cfg.FailOnInvalidGeneratedApplications,
+		FailOnDuplicateGeneratedApplications: cfg.FailOnDuplicateGeneratedApplications,
 	}
 
 	// Get applications for both branches

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,11 +85,12 @@ func run(cfg *Config) error {
 	searchIsLimited := len(selectors) > 0 || len(filesChanged) > 0 || fileRegex != nil
 
 	appSelectionOptions := argoapplication.ApplicationSelectionOptions{
-		Selector:                   selectors,
-		FileRegex:                  fileRegex,
-		FilesChanged:               filesChanged,
-		IgnoreInvalidWatchPattern:  cfg.IgnoreInvalidWatchPattern,
-		WatchIfNoWatchPatternFound: cfg.WatchIfNoWatchPatternFound,
+		Selector:                           selectors,
+		FileRegex:                          fileRegex,
+		FilesChanged:                       filesChanged,
+		IgnoreInvalidWatchPattern:          cfg.IgnoreInvalidWatchPattern,
+		WatchIfNoWatchPatternFound:         cfg.WatchIfNoWatchPatternFound,
+		FailOnInvalidGeneratedApplications: cfg.FailOnInvalidGeneratedApplications,
 	}
 
 	// Get applications for both branches
@@ -250,7 +251,6 @@ func run(cfg *Config) error {
 		tempFolder,
 		redirectRevisions,
 		cfg.Debug,
-		cfg.FailOnDuplicateGeneratedApplications,
 		appSelectionOptions,
 	)
 	if err != nil {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -83,7 +83,8 @@ var (
 	DefaultOutputAppManifests                  = false
 	DefaultOutputBranchManifests               = false
 	DefaultTraverseAppOfApps                   = false
-	DefaultFailOnInvalidGeneratedApplications  = false
+	DefaultFailOnInvalidGeneratedApplications   = false
+	DefaultFailOnDuplicateGeneratedApplications = false
 )
 
 // RawOptions holds the raw CLI/env inputs - used only for parsing
@@ -133,7 +134,8 @@ type RawOptions struct {
 	OutputAppManifests                 bool   `mapstructure:"output-app-manifests"`
 	OutputBranchManifests              bool   `mapstructure:"output-branch-manifests"`
 	TraverseAppOfApps                  bool   `mapstructure:"traverse-app-of-apps"`
-	FailOnInvalidGeneratedApplications bool   `mapstructure:"fail-on-invalid-generated-applications"`
+	FailOnInvalidGeneratedApplications    bool `mapstructure:"fail-on-invalid-generated-applications"`
+	FailOnDuplicateGeneratedApplications  bool `mapstructure:"fail-on-duplicate-generated-applications"` // Deprecated: use FailOnInvalidGeneratedApplications
 }
 
 // Config is the final, validated, ready-to-use configuration
@@ -178,7 +180,8 @@ type Config struct {
 	OutputAppManifests                 bool
 	OutputBranchManifests              bool
 	TraverseAppOfApps                  bool
-	FailOnInvalidGeneratedApplications bool
+	FailOnInvalidGeneratedApplications   bool
+	FailOnDuplicateGeneratedApplications bool // Deprecated: use FailOnInvalidGeneratedApplications
 
 	// Parsed/processed fields - no "parsed" prefix needed
 	FileRegex           *regexp.Regexp
@@ -276,6 +279,7 @@ func Parse() *Config {
 	viper.SetDefault("output-branch-manifests", DefaultOutputBranchManifests)
 	viper.SetDefault("traverse-app-of-apps", DefaultTraverseAppOfApps)
 	viper.SetDefault("fail-on-invalid-generated-applications", DefaultFailOnInvalidGeneratedApplications)
+	viper.SetDefault("fail-on-duplicate-generated-applications", DefaultFailOnDuplicateGeneratedApplications)
 
 	// Basic flags
 	rootCmd.Flags().BoolP("debug", "d", false, "Activate debug mode")
@@ -335,6 +339,7 @@ func Parse() *Config {
 	rootCmd.Flags().Bool("output-branch-manifests", DefaultOutputBranchManifests, "Write all application manifests per branch to a single file (output/base-branch.yaml and output/target-branch.yaml)")
 	rootCmd.Flags().Bool("traverse-app-of-apps", DefaultTraverseAppOfApps, "Recursively render child Applications discovered in rendered manifests (app-of-apps pattern). Only supported with --render-method=repo-server-api")
 	rootCmd.Flags().Bool("fail-on-invalid-generated-applications", DefaultFailOnInvalidGeneratedApplications, "Fail if any generated Application is invalid (missing kind/name, invalid labels, invalid annotation keys, or duplicate names)")
+	rootCmd.Flags().Bool("fail-on-duplicate-generated-applications", DefaultFailOnDuplicateGeneratedApplications, "[Deprecated: use --fail-on-invalid-generated-applications] Fail when a single ApplicationSet generates multiple Applications with the same name")
 
 	// Check if version flag was specified directly
 	for _, arg := range os.Args[1:] {
@@ -421,7 +426,8 @@ func (o *RawOptions) ToConfig() (*Config, error) {
 		OutputAppManifests:                 o.OutputAppManifests,
 		OutputBranchManifests:              o.OutputBranchManifests,
 		TraverseAppOfApps:                  o.TraverseAppOfApps,
-		FailOnInvalidGeneratedApplications: o.FailOnInvalidGeneratedApplications,
+		FailOnInvalidGeneratedApplications:   o.FailOnInvalidGeneratedApplications,
+		FailOnDuplicateGeneratedApplications: o.FailOnDuplicateGeneratedApplications,
 	}
 
 	var err error
@@ -758,5 +764,8 @@ func (o *Config) LogConfig() {
 	}
 	if o.FailOnInvalidGeneratedApplications {
 		log.Info().Msgf("✨ - fail-on-invalid-generated-applications: %t", o.FailOnInvalidGeneratedApplications)
+	}
+	if o.FailOnDuplicateGeneratedApplications {
+		log.Warn().Msg("⚠️ - fail-on-duplicate-generated-applications is deprecated, use --fail-on-invalid-generated-applications instead")
 	}
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -46,139 +46,139 @@ const (
 
 // defaults
 var (
-	DefaultTimeout                              = uint64(180)
-	DefaultLineCount                            = uint(5)
-	DefaultBaseBranch                           = "main"
-	DefaultOutputFolder                         = "./output"
-	DefaultSecretsFolder                        = "./secrets"
-	DefaultCluster                              = "auto"
-	DefaultClusterName                          = "argocd-diff-preview"
-	DefaultKindOptions                          = ""
-	DefaultKindInternal                         = false
-	DefaultK3dOptions                           = ""
-	DefaultMaxDiffLength                        = uint(65536)
-	DefaultArgocdNamespace                      = "argocd"
-	DefaultArgocdChartVersion                   = "latest"
-	DefaultArgocdChartName                      = "argo"
-	DefaultArgocdChartURL                       = "https://argoproj.github.io/argo-helm"
-	DefaultArgocdChartRepoUsername              = ""
-	DefaultArgocdChartRepoPassword              = ""
-	DefaultLogFormat                            = "human"
-	DefaultTitle                                = "Argo CD Diff Preview"
-	DefaultCreateCluster                        = true
-	DefaultKeepClusterAlive                     = false
-	DefaultDryRun                               = false
-	DefaultAutoDetectFilesChanged               = true
-	DefaultWatchIfNoWatchPatternFound           = true
-	DefaultIgnoreInvalidWatchPattern            = false
-	DefaultHideDeletedAppDiff                   = false
-	DefaultIgnoreResourceRules                  = ""
-	DefaultArgocdLoginOptions                   = ""
-	DefaultDisableClientThrottling              = true
-	DefaultArgocdAuthToken                      = ""
-	DefaultArgocdUIURL                          = ""
-	DefaultConcurrency                          = uint(40)
-	DefaultRenderMethod                         = "server-api"
-	DefaultArgocdConfigPath                     = "./argocd-config"
-	DefaultOutputAppManifests                   = false
-	DefaultOutputBranchManifests                = false
-	DefaultTraverseAppOfApps                    = false
-	DefaultFailOnDuplicateGeneratedApplications = false
+	DefaultTimeout                             = uint64(180)
+	DefaultLineCount                           = uint(5)
+	DefaultBaseBranch                          = "main"
+	DefaultOutputFolder                        = "./output"
+	DefaultSecretsFolder                       = "./secrets"
+	DefaultCluster                             = "auto"
+	DefaultClusterName                         = "argocd-diff-preview"
+	DefaultKindOptions                         = ""
+	DefaultKindInternal                        = false
+	DefaultK3dOptions                          = ""
+	DefaultMaxDiffLength                       = uint(65536)
+	DefaultArgocdNamespace                     = "argocd"
+	DefaultArgocdChartVersion                  = "latest"
+	DefaultArgocdChartName                     = "argo"
+	DefaultArgocdChartURL                      = "https://argoproj.github.io/argo-helm"
+	DefaultArgocdChartRepoUsername             = ""
+	DefaultArgocdChartRepoPassword             = ""
+	DefaultLogFormat                           = "human"
+	DefaultTitle                               = "Argo CD Diff Preview"
+	DefaultCreateCluster                       = true
+	DefaultKeepClusterAlive                    = false
+	DefaultDryRun                              = false
+	DefaultAutoDetectFilesChanged              = true
+	DefaultWatchIfNoWatchPatternFound          = true
+	DefaultIgnoreInvalidWatchPattern           = false
+	DefaultHideDeletedAppDiff                  = false
+	DefaultIgnoreResourceRules                 = ""
+	DefaultArgocdLoginOptions                  = ""
+	DefaultDisableClientThrottling             = true
+	DefaultArgocdAuthToken                     = ""
+	DefaultArgocdUIURL                         = ""
+	DefaultConcurrency                         = uint(40)
+	DefaultRenderMethod                        = "server-api"
+	DefaultArgocdConfigPath                    = "./argocd-config"
+	DefaultOutputAppManifests                  = false
+	DefaultOutputBranchManifests               = false
+	DefaultTraverseAppOfApps                   = false
+	DefaultFailOnInvalidGeneratedApplications  = false
 )
 
 // RawOptions holds the raw CLI/env inputs - used only for parsing
 type RawOptions struct {
-	Debug                                bool   `mapstructure:"debug"`
-	DryRun                               bool   `mapstructure:"dry-run"`
-	Timeout                              uint64 `mapstructure:"timeout"`
-	FileRegex                            string `mapstructure:"file-regex"`
-	DiffIgnore                           string `mapstructure:"diff-ignore"`
-	LineCount                            uint   `mapstructure:"line-count"`
-	BaseBranch                           string `mapstructure:"base-branch"`
-	TargetBranch                         string `mapstructure:"target-branch"`
-	Repo                                 string `mapstructure:"repo"`
-	OutputFolder                         string `mapstructure:"output-folder"`
-	SecretsFolder                        string `mapstructure:"secrets-folder"`
-	CreateCluster                        bool   `mapstructure:"create-cluster"`
-	ClusterType                          string `mapstructure:"cluster"`
-	ClusterName                          string `mapstructure:"cluster-name"`
-	KindOptions                          string `mapstructure:"kind-options"`
-	KindInternal                         bool   `mapstructure:"kind-internal"`
-	K3dOptions                           string `mapstructure:"k3d-options"`
-	MaxDiffLength                        uint   `mapstructure:"max-diff-length"`
-	Selector                             string `mapstructure:"selector"`
-	FilesChanged                         string `mapstructure:"files-changed"`
-	IgnoreInvalidWatchPattern            bool   `mapstructure:"ignore-invalid-watch-pattern"`
-	WatchIfNoWatchPatternFound           bool   `mapstructure:"watch-if-no-watch-pattern-found"`
-	AutoDetectFilesChanged               bool   `mapstructure:"auto-detect-files-changed"`
-	KeepClusterAlive                     bool   `mapstructure:"keep-cluster-alive"`
-	ArgocdNamespace                      string `mapstructure:"argocd-namespace"`
-	ArgocdChartVersion                   string `mapstructure:"argocd-chart-version"`
-	ArgocdChartName                      string `mapstructure:"argocd-chart-name"`
-	ArgocdChartURL                       string `mapstructure:"argocd-chart-url"`
-	ArgocdChartRepoUsername              string `mapstructure:"argocd-chart-repo-username"`
-	ArgocdChartRepoPassword              string `mapstructure:"argocd-chart-repo-password"`
-	ArgocdLoginOptions                   string `mapstructure:"argocd-login-options"`
-	ArgocdAuthToken                      string `mapstructure:"argocd-auth-token"`
-	ArgocdConfigPath                     string `mapstructure:"argocd-config-dir"`
-	RenderMethod                         string `mapstructure:"render-method"`
-	RedirectTargetRevisions              string `mapstructure:"redirect-target-revisions"`
-	LogFormat                            string `mapstructure:"log-format"`
-	Title                                string `mapstructure:"title"`
-	HideDeletedAppDiff                   bool   `mapstructure:"hide-deleted-app-diff"`
-	IgnoreResourceRules                  string `mapstructure:"ignore-resources"`
-	DisableClientThrottling              bool   `mapstructure:"disable-client-throttling"`
-	ArgocdUIURL                          string `mapstructure:"argocd-ui-url"`
-	Concurrency                          uint   `mapstructure:"concurrency"`
-	OutputAppManifests                   bool   `mapstructure:"output-app-manifests"`
-	OutputBranchManifests                bool   `mapstructure:"output-branch-manifests"`
-	TraverseAppOfApps                    bool   `mapstructure:"traverse-app-of-apps"`
-	FailOnDuplicateGeneratedApplications bool   `mapstructure:"fail-on-duplicate-generated-applications"`
+	Debug                              bool   `mapstructure:"debug"`
+	DryRun                             bool   `mapstructure:"dry-run"`
+	Timeout                            uint64 `mapstructure:"timeout"`
+	FileRegex                          string `mapstructure:"file-regex"`
+	DiffIgnore                         string `mapstructure:"diff-ignore"`
+	LineCount                          uint   `mapstructure:"line-count"`
+	BaseBranch                         string `mapstructure:"base-branch"`
+	TargetBranch                       string `mapstructure:"target-branch"`
+	Repo                               string `mapstructure:"repo"`
+	OutputFolder                       string `mapstructure:"output-folder"`
+	SecretsFolder                      string `mapstructure:"secrets-folder"`
+	CreateCluster                      bool   `mapstructure:"create-cluster"`
+	ClusterType                        string `mapstructure:"cluster"`
+	ClusterName                        string `mapstructure:"cluster-name"`
+	KindOptions                        string `mapstructure:"kind-options"`
+	KindInternal                       bool   `mapstructure:"kind-internal"`
+	K3dOptions                         string `mapstructure:"k3d-options"`
+	MaxDiffLength                      uint   `mapstructure:"max-diff-length"`
+	Selector                           string `mapstructure:"selector"`
+	FilesChanged                       string `mapstructure:"files-changed"`
+	IgnoreInvalidWatchPattern          bool   `mapstructure:"ignore-invalid-watch-pattern"`
+	WatchIfNoWatchPatternFound         bool   `mapstructure:"watch-if-no-watch-pattern-found"`
+	AutoDetectFilesChanged             bool   `mapstructure:"auto-detect-files-changed"`
+	KeepClusterAlive                   bool   `mapstructure:"keep-cluster-alive"`
+	ArgocdNamespace                    string `mapstructure:"argocd-namespace"`
+	ArgocdChartVersion                 string `mapstructure:"argocd-chart-version"`
+	ArgocdChartName                    string `mapstructure:"argocd-chart-name"`
+	ArgocdChartURL                     string `mapstructure:"argocd-chart-url"`
+	ArgocdChartRepoUsername            string `mapstructure:"argocd-chart-repo-username"`
+	ArgocdChartRepoPassword            string `mapstructure:"argocd-chart-repo-password"`
+	ArgocdLoginOptions                 string `mapstructure:"argocd-login-options"`
+	ArgocdAuthToken                    string `mapstructure:"argocd-auth-token"`
+	ArgocdConfigPath                   string `mapstructure:"argocd-config-dir"`
+	RenderMethod                       string `mapstructure:"render-method"`
+	RedirectTargetRevisions            string `mapstructure:"redirect-target-revisions"`
+	LogFormat                          string `mapstructure:"log-format"`
+	Title                              string `mapstructure:"title"`
+	HideDeletedAppDiff                 bool   `mapstructure:"hide-deleted-app-diff"`
+	IgnoreResourceRules                string `mapstructure:"ignore-resources"`
+	DisableClientThrottling            bool   `mapstructure:"disable-client-throttling"`
+	ArgocdUIURL                        string `mapstructure:"argocd-ui-url"`
+	Concurrency                        uint   `mapstructure:"concurrency"`
+	OutputAppManifests                 bool   `mapstructure:"output-app-manifests"`
+	OutputBranchManifests              bool   `mapstructure:"output-branch-manifests"`
+	TraverseAppOfApps                  bool   `mapstructure:"traverse-app-of-apps"`
+	FailOnInvalidGeneratedApplications bool   `mapstructure:"fail-on-invalid-generated-applications"`
 }
 
 // Config is the final, validated, ready-to-use configuration
 type Config struct {
 	// Direct passthrough fields
-	Debug                                bool
-	DryRun                               bool
-	Timeout                              uint64
-	DiffIgnore                           string
-	LineCount                            uint
-	BaseBranch                           string
-	TargetBranch                         string
-	Repo                                 string
-	OutputFolder                         string
-	SecretsFolder                        string
-	CreateCluster                        bool
-	ClusterName                          string
-	KindOptions                          string
-	KindInternal                         bool
-	K3dOptions                           string
-	MaxDiffLength                        uint
-	IgnoreInvalidWatchPattern            bool
-	WatchIfNoWatchPatternFound           bool
-	AutoDetectFilesChanged               bool
-	KeepClusterAlive                     bool
-	ArgocdNamespace                      string
-	ArgocdChartVersion                   string
-	ArgocdChartName                      string
-	ArgocdChartURL                       string
-	ArgocdChartRepoUsername              string
-	ArgocdChartRepoPassword              string
-	ArgocdLoginOptions                   string
-	ArgocdAuthToken                      string
-	ArgocdConfigPath                     string
-	LogFormat                            string
-	Title                                string
-	HideDeletedAppDiff                   bool
-	DisableClientThrottling              bool
-	RenderMethod                         RenderMethod
-	ArgocdUIURL                          string
-	Concurrency                          uint
-	OutputAppManifests                   bool
-	OutputBranchManifests                bool
-	TraverseAppOfApps                    bool
-	FailOnDuplicateGeneratedApplications bool
+	Debug                              bool
+	DryRun                             bool
+	Timeout                            uint64
+	DiffIgnore                         string
+	LineCount                          uint
+	BaseBranch                         string
+	TargetBranch                       string
+	Repo                               string
+	OutputFolder                       string
+	SecretsFolder                      string
+	CreateCluster                      bool
+	ClusterName                        string
+	KindOptions                        string
+	KindInternal                       bool
+	K3dOptions                         string
+	MaxDiffLength                      uint
+	IgnoreInvalidWatchPattern          bool
+	WatchIfNoWatchPatternFound         bool
+	AutoDetectFilesChanged             bool
+	KeepClusterAlive                   bool
+	ArgocdNamespace                    string
+	ArgocdChartVersion                 string
+	ArgocdChartName                    string
+	ArgocdChartURL                     string
+	ArgocdChartRepoUsername            string
+	ArgocdChartRepoPassword            string
+	ArgocdLoginOptions                 string
+	ArgocdAuthToken                    string
+	ArgocdConfigPath                   string
+	LogFormat                          string
+	Title                              string
+	HideDeletedAppDiff                 bool
+	DisableClientThrottling            bool
+	RenderMethod                       RenderMethod
+	ArgocdUIURL                        string
+	Concurrency                        uint
+	OutputAppManifests                 bool
+	OutputBranchManifests              bool
+	TraverseAppOfApps                  bool
+	FailOnInvalidGeneratedApplications bool
 
 	// Parsed/processed fields - no "parsed" prefix needed
 	FileRegex           *regexp.Regexp
@@ -275,7 +275,7 @@ func Parse() *Config {
 	viper.SetDefault("output-app-manifests", DefaultOutputAppManifests)
 	viper.SetDefault("output-branch-manifests", DefaultOutputBranchManifests)
 	viper.SetDefault("traverse-app-of-apps", DefaultTraverseAppOfApps)
-	viper.SetDefault("fail-on-duplicate-generated-applications", DefaultFailOnDuplicateGeneratedApplications)
+	viper.SetDefault("fail-on-invalid-generated-applications", DefaultFailOnInvalidGeneratedApplications)
 
 	// Basic flags
 	rootCmd.Flags().BoolP("debug", "d", false, "Activate debug mode")
@@ -334,7 +334,7 @@ func Parse() *Config {
 	rootCmd.Flags().Bool("output-app-manifests", DefaultOutputAppManifests, "Write per-application manifest files to the output folder (output/base/ and output/target/)")
 	rootCmd.Flags().Bool("output-branch-manifests", DefaultOutputBranchManifests, "Write all application manifests per branch to a single file (output/base-branch.yaml and output/target-branch.yaml)")
 	rootCmd.Flags().Bool("traverse-app-of-apps", DefaultTraverseAppOfApps, "Recursively render child Applications discovered in rendered manifests (app-of-apps pattern). Only supported with --render-method=repo-server-api")
-	rootCmd.Flags().Bool("fail-on-duplicate-generated-applications", DefaultFailOnDuplicateGeneratedApplications, "Fail when a single ApplicationSet generates multiple Applications with the same name")
+	rootCmd.Flags().Bool("fail-on-invalid-generated-applications", DefaultFailOnInvalidGeneratedApplications, "Fail if any generated Application is invalid (missing kind/name, invalid labels, invalid annotation keys, or duplicate names)")
 
 	// Check if version flag was specified directly
 	for _, arg := range os.Args[1:] {
@@ -383,45 +383,45 @@ func (o *RawOptions) checkRequired() []string {
 func (o *RawOptions) ToConfig() (*Config, error) {
 	cfg := &Config{
 		// Direct passthrough fields
-		Debug:                                o.Debug,
-		DryRun:                               o.DryRun,
-		Timeout:                              o.Timeout,
-		DiffIgnore:                           o.DiffIgnore,
-		LineCount:                            o.LineCount,
-		BaseBranch:                           o.BaseBranch,
-		TargetBranch:                         o.TargetBranch,
-		Repo:                                 o.Repo,
-		OutputFolder:                         o.OutputFolder,
-		SecretsFolder:                        o.SecretsFolder,
-		CreateCluster:                        o.CreateCluster,
-		ClusterName:                          o.ClusterName,
-		KindOptions:                          o.KindOptions,
-		KindInternal:                         o.KindInternal,
-		K3dOptions:                           o.K3dOptions,
-		MaxDiffLength:                        o.MaxDiffLength,
-		IgnoreInvalidWatchPattern:            o.IgnoreInvalidWatchPattern,
-		WatchIfNoWatchPatternFound:           o.WatchIfNoWatchPatternFound,
-		AutoDetectFilesChanged:               o.AutoDetectFilesChanged,
-		KeepClusterAlive:                     o.KeepClusterAlive,
-		ArgocdNamespace:                      o.ArgocdNamespace,
-		ArgocdChartVersion:                   o.ArgocdChartVersion,
-		ArgocdChartName:                      o.ArgocdChartName,
-		ArgocdChartURL:                       o.ArgocdChartURL,
-		ArgocdChartRepoUsername:              o.ArgocdChartRepoUsername,
-		ArgocdChartRepoPassword:              o.ArgocdChartRepoPassword,
-		ArgocdLoginOptions:                   o.ArgocdLoginOptions,
-		ArgocdAuthToken:                      o.ArgocdAuthToken,
-		ArgocdConfigPath:                     o.ArgocdConfigPath,
-		LogFormat:                            o.LogFormat,
-		Title:                                o.Title,
-		HideDeletedAppDiff:                   o.HideDeletedAppDiff,
-		DisableClientThrottling:              o.DisableClientThrottling,
-		ArgocdUIURL:                          o.ArgocdUIURL,
-		Concurrency:                          o.Concurrency,
-		OutputAppManifests:                   o.OutputAppManifests,
-		OutputBranchManifests:                o.OutputBranchManifests,
-		TraverseAppOfApps:                    o.TraverseAppOfApps,
-		FailOnDuplicateGeneratedApplications: o.FailOnDuplicateGeneratedApplications,
+		Debug:                              o.Debug,
+		DryRun:                             o.DryRun,
+		Timeout:                            o.Timeout,
+		DiffIgnore:                         o.DiffIgnore,
+		LineCount:                          o.LineCount,
+		BaseBranch:                         o.BaseBranch,
+		TargetBranch:                       o.TargetBranch,
+		Repo:                               o.Repo,
+		OutputFolder:                       o.OutputFolder,
+		SecretsFolder:                      o.SecretsFolder,
+		CreateCluster:                      o.CreateCluster,
+		ClusterName:                        o.ClusterName,
+		KindOptions:                        o.KindOptions,
+		KindInternal:                       o.KindInternal,
+		K3dOptions:                         o.K3dOptions,
+		MaxDiffLength:                      o.MaxDiffLength,
+		IgnoreInvalidWatchPattern:          o.IgnoreInvalidWatchPattern,
+		WatchIfNoWatchPatternFound:         o.WatchIfNoWatchPatternFound,
+		AutoDetectFilesChanged:             o.AutoDetectFilesChanged,
+		KeepClusterAlive:                   o.KeepClusterAlive,
+		ArgocdNamespace:                    o.ArgocdNamespace,
+		ArgocdChartVersion:                 o.ArgocdChartVersion,
+		ArgocdChartName:                    o.ArgocdChartName,
+		ArgocdChartURL:                     o.ArgocdChartURL,
+		ArgocdChartRepoUsername:            o.ArgocdChartRepoUsername,
+		ArgocdChartRepoPassword:            o.ArgocdChartRepoPassword,
+		ArgocdLoginOptions:                 o.ArgocdLoginOptions,
+		ArgocdAuthToken:                    o.ArgocdAuthToken,
+		ArgocdConfigPath:                   o.ArgocdConfigPath,
+		LogFormat:                          o.LogFormat,
+		Title:                              o.Title,
+		HideDeletedAppDiff:                 o.HideDeletedAppDiff,
+		DisableClientThrottling:            o.DisableClientThrottling,
+		ArgocdUIURL:                        o.ArgocdUIURL,
+		Concurrency:                        o.Concurrency,
+		OutputAppManifests:                 o.OutputAppManifests,
+		OutputBranchManifests:              o.OutputBranchManifests,
+		TraverseAppOfApps:                  o.TraverseAppOfApps,
+		FailOnInvalidGeneratedApplications: o.FailOnInvalidGeneratedApplications,
 	}
 
 	var err error
@@ -756,7 +756,7 @@ func (o *Config) LogConfig() {
 	if o.TraverseAppOfApps {
 		log.Info().Msgf("✨ - traverse-app-of-apps: %t", o.TraverseAppOfApps)
 	}
-	if o.FailOnDuplicateGeneratedApplications {
-		log.Info().Msgf("✨ - fail-on-duplicate-generated-applications: %t", o.FailOnDuplicateGeneratedApplications)
+	if o.FailOnInvalidGeneratedApplications {
+		log.Info().Msgf("✨ - fail-on-invalid-generated-applications: %t", o.FailOnInvalidGeneratedApplications)
 	}
 }

--- a/pkg/argoapplication/application_sets.go
+++ b/pkg/argoapplication/application_sets.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/dag-andersen/argocd-diff-preview/pkg/argocd"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/git"
@@ -24,7 +25,6 @@ func ConvertAppSetsToAppsInBothBranches(
 	tempFolder string,
 	redirectRevisions []string,
 	debug bool,
-	failOnDuplicateGeneratedApplications bool,
 	appSelectionOptions ApplicationSelectionOptions,
 ) (*ArgoSelection, *ArgoSelection, time.Duration, error) {
 	startTime := time.Now()
@@ -38,7 +38,6 @@ func ConvertAppSetsToAppsInBothBranches(
 		baseBranch,
 		baseTempFolder,
 		debug,
-		failOnDuplicateGeneratedApplications,
 		appSelectionOptions,
 		repo,
 		redirectRevisions,
@@ -56,7 +55,6 @@ func ConvertAppSetsToAppsInBothBranches(
 		targetBranch,
 		targetTempFolder,
 		debug,
-		failOnDuplicateGeneratedApplications,
 		appSelectionOptions,
 		repo,
 		redirectRevisions,
@@ -77,7 +75,6 @@ func processAppSets(
 	branch *git.Branch,
 	tempFolder string,
 	debug bool,
-	failOnDuplicateGeneratedApplications bool,
 	appSelectionOptions ApplicationSelectionOptions,
 	repo string,
 	redirectRevisions []string,
@@ -89,7 +86,7 @@ func processAppSets(
 		branch,
 		tempFolder,
 		debug,
-		failOnDuplicateGeneratedApplications,
+		appSelectionOptions.FailOnInvalidGeneratedApplications,
 	)
 	if err != nil {
 		log.Error().Str("branch", branch.Name).Msg("❌ Failed to generate apps")
@@ -205,7 +202,7 @@ func convertAppSetsToApps(
 	branch *git.Branch,
 	tempFolder string,
 	debug bool,
-	failOnDuplicateGeneratedApplications bool,
+	failOnInvalid bool,
 ) (*AppSetConversionResult, error) {
 
 	log.Debug().Str("branch", branch.Name).Msg("🤖 Generating Applications from ApplicationSets")
@@ -251,7 +248,7 @@ func convertAppSetsToApps(
 			defer wg.Done()
 			defer func() { <-sem }() // release semaphore slot
 
-			apps, err := generateAppsFromAppSet(argocd, appSet, branch, tempFolder, failOnDuplicateGeneratedApplications)
+			apps, err := generateAppsFromAppSet(argocd, appSet, branch, tempFolder, failOnInvalid)
 			results <- appSetGenerateResult{index: i, apps: apps, err: err}
 		}(i, appSet)
 	}
@@ -298,7 +295,7 @@ func generateAppsFromAppSet(
 	appSet ArgoResource,
 	branch *git.Branch,
 	tempFolder string,
-	failOnDuplicateGeneratedApplications bool,
+	failOnInvalid bool,
 ) ([]ArgoResource, error) {
 	retryCount := 5
 	generatedApps, err := argocd.AppsetGenerateWithRetry(appSet.Yaml, tempFolder, retryCount)
@@ -316,21 +313,47 @@ func generateAppsFromAppSet(
 	for _, doc := range generatedApps {
 		kind := doc.GetKind()
 		if kind == "" {
-			log.Error().
-				Str(appSet.Kind.ShortName(), appSet.GetLongName()).
-				Msg("❌ Output from ApplicationSet contains no kind")
+			msg := "❌ Output from ApplicationSet contains no kind"
+			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg(msg)
+			if failOnInvalid {
+				return nil, fmt.Errorf("%s: %s", msg, appSet.GetLongName())
+			}
 			continue
 		}
 		if kind != "Application" {
-			log.Error().
-				Str(appSet.Kind.ShortName(), appSet.GetLongName()).
-				Msg("❌ Output from ApplicationSet contains non-Application resources")
+			msg := fmt.Sprintf("❌ Output from ApplicationSet contains non-Application resource of kind '%s'", kind)
+			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg(msg)
+			if failOnInvalid {
+				return nil, fmt.Errorf("%s: %s", msg, appSet.GetLongName())
+			}
 			continue
 		}
 
 		name := doc.GetName()
 		if name == "" {
-			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg("❌ Generated Application missing name")
+			msg := "❌ Generated Application missing name"
+			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg(msg)
+			if failOnInvalid {
+				return nil, fmt.Errorf("%s: %s", msg, appSet.GetLongName())
+			}
+			continue
+		}
+
+		if err := validateLabels(doc.GetLabels()); err != nil {
+			msg := fmt.Sprintf("❌ Generated Application '%s' has invalid labels: %s", name, err)
+			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg(msg)
+			if failOnInvalid {
+				return nil, fmt.Errorf("%s: %s", msg, appSet.GetLongName())
+			}
+			continue
+		}
+
+		if err := validateAnnotations(doc.GetAnnotations()); err != nil {
+			msg := fmt.Sprintf("❌ Generated Application '%s' has invalid annotations: %s", name, err)
+			log.Error().Str(appSet.Kind.ShortName(), appSet.GetLongName()).Msg(msg)
+			if failOnInvalid {
+				return nil, fmt.Errorf("%s: %s", msg, appSet.GetLongName())
+			}
 			continue
 		}
 
@@ -339,7 +362,7 @@ func generateAppsFromAppSet(
 		apps = append(apps, *app)
 	}
 
-	if err := validateGeneratedApplicationNames(appSet, apps, branch, failOnDuplicateGeneratedApplications); err != nil {
+	if err := validateGeneratedApplicationNames(appSet, apps, branch, failOnInvalid); err != nil {
 		return nil, err
 	}
 
@@ -372,7 +395,7 @@ func validateGeneratedApplicationNames(
 	appSet ArgoResource,
 	apps []ArgoResource,
 	branch *git.Branch,
-	failOnDuplicateGeneratedApplications bool,
+	failOnInvalid bool,
 ) error {
 	duplicates := duplicateGeneratedApplicationNames(apps)
 	if len(duplicates) == 0 {
@@ -385,14 +408,43 @@ func validateGeneratedApplicationNames(
 		strings.Join(duplicates, ", "),
 	)
 
-	if failOnDuplicateGeneratedApplications {
+	if failOnInvalid {
 		return fmt.Errorf("%s", msg)
 	}
 
 	log.Warn().
 		Str("branch", branch.Name).
 		Str(appSet.Kind.ShortName(), appSet.GetLongName()).
-		Msgf("⚠️ %s. Continuing because --fail-on-duplicate-generated-applications is not enabled", msg)
+		Msgf("⚠️ %s. Continuing because --fail-on-invalid-generated-applications is not enabled", msg)
 
+	return nil
+}
+
+func validateLabels(labels map[string]string) error {
+	var errs []string
+	for k, v := range labels {
+		if msgs := k8svalidation.IsQualifiedName(k); len(msgs) > 0 {
+			errs = append(errs, fmt.Sprintf("invalid label key %q: %s", k, strings.Join(msgs, "; ")))
+		}
+		if msgs := k8svalidation.IsValidLabelValue(v); len(msgs) > 0 {
+			errs = append(errs, fmt.Sprintf("invalid label value %q for key %q: %s", v, k, strings.Join(msgs, "; ")))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+func validateAnnotations(annotations map[string]string) error {
+	var errs []string
+	for k := range annotations {
+		if msgs := k8svalidation.IsQualifiedName(k); len(msgs) > 0 {
+			errs = append(errs, fmt.Sprintf("invalid annotation key %q: %s", k, strings.Join(msgs, "; ")))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, ", "))
+	}
 	return nil
 }

--- a/pkg/argoapplication/application_sets.go
+++ b/pkg/argoapplication/application_sets.go
@@ -87,6 +87,7 @@ func processAppSets(
 		tempFolder,
 		debug,
 		appSelectionOptions.FailOnInvalidGeneratedApplications,
+		appSelectionOptions.FailOnDuplicateGeneratedApplications,
 	)
 	if err != nil {
 		log.Error().Str("branch", branch.Name).Msg("❌ Failed to generate apps")
@@ -203,6 +204,7 @@ func convertAppSetsToApps(
 	tempFolder string,
 	debug bool,
 	failOnInvalid bool,
+	failOnDuplicate bool,
 ) (*AppSetConversionResult, error) {
 
 	log.Debug().Str("branch", branch.Name).Msg("🤖 Generating Applications from ApplicationSets")
@@ -248,7 +250,7 @@ func convertAppSetsToApps(
 			defer wg.Done()
 			defer func() { <-sem }() // release semaphore slot
 
-			apps, err := generateAppsFromAppSet(argocd, appSet, branch, tempFolder, failOnInvalid)
+			apps, err := generateAppsFromAppSet(argocd, appSet, branch, tempFolder, failOnInvalid, failOnDuplicate)
 			results <- appSetGenerateResult{index: i, apps: apps, err: err}
 		}(i, appSet)
 	}
@@ -296,6 +298,7 @@ func generateAppsFromAppSet(
 	branch *git.Branch,
 	tempFolder string,
 	failOnInvalid bool,
+	failOnDuplicate bool,
 ) ([]ArgoResource, error) {
 	retryCount := 5
 	generatedApps, err := argocd.AppsetGenerateWithRetry(appSet.Yaml, tempFolder, retryCount)
@@ -362,7 +365,7 @@ func generateAppsFromAppSet(
 		apps = append(apps, *app)
 	}
 
-	if err := validateGeneratedApplicationNames(appSet, apps, branch, failOnInvalid); err != nil {
+	if err := validateGeneratedApplicationNames(appSet, apps, branch, failOnInvalid, failOnDuplicate); err != nil {
 		return nil, err
 	}
 
@@ -396,6 +399,7 @@ func validateGeneratedApplicationNames(
 	apps []ArgoResource,
 	branch *git.Branch,
 	failOnInvalid bool,
+	failOnDuplicate bool,
 ) error {
 	duplicates := duplicateGeneratedApplicationNames(apps)
 	if len(duplicates) == 0 {
@@ -408,14 +412,14 @@ func validateGeneratedApplicationNames(
 		strings.Join(duplicates, ", "),
 	)
 
-	if failOnInvalid {
+	if failOnInvalid || failOnDuplicate {
 		return fmt.Errorf("%s", msg)
 	}
 
 	log.Warn().
 		Str("branch", branch.Name).
 		Str(appSet.Kind.ShortName(), appSet.GetLongName()).
-		Msgf("⚠️ %s. Continuing because --fail-on-invalid-generated-applications is not enabled", msg)
+		Msgf("⚠️ %s. Continuing because neither --fail-on-invalid-generated-applications nor --fail-on-duplicate-generated-applications is enabled", msg)
 
 	return nil
 }

--- a/pkg/argoapplication/application_sets_duplicates_test.go
+++ b/pkg/argoapplication/application_sets_duplicates_test.go
@@ -33,7 +33,7 @@ func TestValidateGeneratedApplicationNames(t *testing.T) {
 			createGeneratedApplicationForTest("dupe", "appset.yaml"),
 		}
 
-		require.NoError(t, validateGeneratedApplicationNames(appSet, apps, branch, false))
+		require.NoError(t, validateGeneratedApplicationNames(appSet, apps, branch, false, false))
 	})
 
 	t.Run("strict mode fails", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestValidateGeneratedApplicationNames(t *testing.T) {
 			createGeneratedApplicationForTest("other", "appset.yaml"),
 		}
 
-		err := validateGeneratedApplicationNames(appSet, apps, branch, true)
+		err := validateGeneratedApplicationNames(appSet, apps, branch, true, false)
 		require.EqualError(t, err, "ApplicationSet duplicate-generated-apps [t|appset.yaml] generated applications with duplicate names: dupe, other")
 	})
 
@@ -55,8 +55,8 @@ func TestValidateGeneratedApplicationNames(t *testing.T) {
 		baseApps := []ArgoResource{createGeneratedApplicationForTest("app-1", "base-appset.yaml")}
 		targetApps := []ArgoResource{createGeneratedApplicationForTest("app-1", "target-appset.yaml")}
 
-		require.NoError(t, validateGeneratedApplicationNames(baseAppSet, baseApps, git.NewBranch("main", git.Base), true))
-		require.NoError(t, validateGeneratedApplicationNames(targetAppSet, targetApps, git.NewBranch("feature", git.Target), true))
+		require.NoError(t, validateGeneratedApplicationNames(baseAppSet, baseApps, git.NewBranch("main", git.Base), true, false))
+		require.NoError(t, validateGeneratedApplicationNames(targetAppSet, targetApps, git.NewBranch("feature", git.Target), true, false))
 	})
 }
 

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -33,12 +33,13 @@ const (
 )
 
 type ApplicationSelectionOptions struct {
-	FileRegex                          *regexp.Regexp
-	Selector                           []app_selector.Selector
-	FilesChanged                       []string
-	IgnoreInvalidWatchPattern          bool
-	WatchIfNoWatchPatternFound         bool
-	FailOnInvalidGeneratedApplications bool
+	FileRegex                             *regexp.Regexp
+	Selector                              []app_selector.Selector
+	FilesChanged                          []string
+	IgnoreInvalidWatchPattern             bool
+	WatchIfNoWatchPatternFound            bool
+	FailOnInvalidGeneratedApplications    bool
+	FailOnDuplicateGeneratedApplications  bool // Deprecated: use FailOnInvalidGeneratedApplications
 }
 
 const maxFilesChangedDisplay = 20

--- a/pkg/argoapplication/filter.go
+++ b/pkg/argoapplication/filter.go
@@ -33,11 +33,12 @@ const (
 )
 
 type ApplicationSelectionOptions struct {
-	FileRegex                  *regexp.Regexp
-	Selector                   []app_selector.Selector
-	FilesChanged               []string
-	IgnoreInvalidWatchPattern  bool
-	WatchIfNoWatchPatternFound bool
+	FileRegex                          *regexp.Regexp
+	Selector                           []app_selector.Selector
+	FilesChanged                       []string
+	IgnoreInvalidWatchPattern          bool
+	WatchIfNoWatchPatternFound         bool
+	FailOnInvalidGeneratedApplications bool
 }
 
 const maxFilesChangedDisplay = 20


### PR DESCRIPTION
Adds a flag that causes hard failures instead of silent skips when
ApplicationSet generation produces invalid Applications — specifically:
missing kind, non-Application kinds, missing name, invalid label keys/values,
or invalid annotation keys. Previously these were logged as errors but
silently dropped, which could mask misconfigured ApplicationSets.