### PR TITLE
Fix | Handle external ref sources when using repo-serve-api

### DIFF
--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -563,7 +563,7 @@ func buildManifestRequestForSource(
 		}
 		return newManifestRequest(&primarySource), branchFolder, nil, nil
 	}
-	// ── Slow path: ref sources present ───────────────────────────────────────
+	// Slow path: ref sources present
 	//
 	// Special case: external Helm chart primary source WITH ref sources.
 	// Example pattern (cluster-common-charts ApplicationSet):
@@ -579,38 +579,27 @@ func buildManifestRequestForSource(
 	// repo server fetches the ref content from its own git cache. The $ref/…
 	// value file paths are left unchanged (no rewriting needed).
 	if primarySource.Chart != "" {
-		refSourcesMap := make(map[string]*v1alpha1.RefTarget, len(refSources))
-		for _, ref := range refSources {
-			refSourcesMap["$"+ref.Ref] = &v1alpha1.RefTarget{
-				Repo:           *creds.GetRepo(ref.RepoURL),
-				TargetRevision: ref.TargetRevision,
-			}
-		}
 		request = newManifestRequest(&primarySource)
-		request.RefSources = refSourcesMap
+		request.RefSources = buildRefSourcesMap(refSources, creds)
 		return request, "", nil, nil
 	}
 
-	// ── Slow path: ref sources present - cross-repo primary source ────────────
+	// Slow path: ref sources present - cross-repo primary or ref source
 	// When the primary source lives in a different repository from the PR, we
 	// cannot stream its files locally. Use the remote RPC and let the repo
 	// server fetch both the primary content and the ref sources from their
 	// respective git caches. Value-file $ref/… paths are left unrewritten.
-	if prRepo != "" && !repoURLContains(primarySource.RepoURL, prRepo) {
+	// The same applies when a ref source lives outside the PR repository. Copying
+	// the local branch folder into .refs would provide the wrong repository
+	// content, especially for ref-only sources whose Path is empty.
+	if prRepo != "" && (!repoURLContains(primarySource.RepoURL, prRepo) || hasExternalRefSource(refSources, prRepo)) {
 		log.Debug().
 			Str("App", app.GetLongName()).
 			Str("sourceRepoURL", primarySource.RepoURL).
 			Str("prRepo", prRepo).
-			Msg("Source repoURL does not match PR repo (slow path) - using remote RPC")
-		refSourcesMap := make(map[string]*v1alpha1.RefTarget, len(refSources))
-		for _, ref := range refSources {
-			refSourcesMap["$"+ref.Ref] = &v1alpha1.RefTarget{
-				Repo:           *creds.GetRepo(ref.RepoURL),
-				TargetRevision: ref.TargetRevision,
-			}
-		}
+			Msg("Source or ref repoURL does not match PR repo (slow path) - using remote RPC")
 		request = newManifestRequest(&primarySource)
-		request.RefSources = refSourcesMap
+		request.RefSources = buildRefSourcesMap(refSources, creds)
 		return request, "", nil, nil
 	}
 
@@ -704,6 +693,26 @@ func splitRefPath(valueFile string) (refName, path string, ok bool) {
 		return "", "", false
 	}
 	return refName, path, true
+}
+
+func buildRefSourcesMap(refSources []v1alpha1.ApplicationSource, creds *RepoCreds) map[string]*v1alpha1.RefTarget {
+	refSourcesMap := make(map[string]*v1alpha1.RefTarget, len(refSources))
+	for _, ref := range refSources {
+		refSourcesMap["$"+ref.Ref] = &v1alpha1.RefTarget{
+			Repo:           *creds.GetRepo(ref.RepoURL),
+			TargetRevision: ref.TargetRevision,
+		}
+	}
+	return refSourcesMap
+}
+
+func hasExternalRefSource(refSources []v1alpha1.ApplicationSource, prRepo string) bool {
+	for _, ref := range refSources {
+		if !repoURLContains(ref.RepoURL, prRepo) {
+			return true
+		}
+	}
+	return false
 }
 
 // copyDir recursively copies src into dst, creating dst if needed.

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -669,6 +669,53 @@ spec:
 	assertDefaultProjectFields(t, req)
 }
 
+func TestBuildManifestRequest_SameRepoPrimaryWithExternalRef_UsesRemoteRPC(t *testing.T) {
+	prRepo := "org/helm-charts"
+	branchFolder := makeBranchFolder(t, "charts/my-chart")
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  destination:
+    namespace: production
+  sources:
+    - repoURL: https://github.com/org/helm-charts.git
+      path: charts/my-chart
+      targetRevision: main
+      helm:
+        valueFiles:
+          - $helm-values-repo/values.yaml
+    - repoURL: https://github.com/org/app-values.git
+      targetRevision: main
+      ref: helm-values-repo
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+	require.Len(t, refSources, 1)
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, prRepo)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	assert.Empty(t, streamDir,
+		"external ref source must use remote RPC so repo server fetches ref repository instead of copying PR repo root")
+	assert.Equal(t, []string{"$helm-values-repo/values.yaml"}, req.ApplicationSource.Helm.ValueFiles,
+		"remote RPC must keep $ref value files unchanged")
+	require.NotNil(t, req.RefSources)
+	refTarget, ok := req.RefSources["$helm-values-repo"]
+	require.True(t, ok)
+	assert.Equal(t, "https://github.com/org/app-values.git", refTarget.Repo.Repo)
+	assert.Equal(t, "main", refTarget.TargetRevision)
+	assertDefaultProjectFields(t, req)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // repocreds: GetRepo normalises .git suffix on lookup
 //


### PR DESCRIPTION
## Summary
- Use remote repo-server RPC when a multi-source app has external ref sources.
- Add regression coverage for same-repo primary sources with external refs.

## Testing
- go test ./pkg/reposerverextract