### PR TITLE
fix: Repo server concurrency fix

### DIFF
--- a/argocd-config/values-override.yaml
+++ b/argocd-config/values-override.yaml
@@ -29,6 +29,11 @@ repoServer:
     successThreshold: 1
     timeoutSeconds: 1
     failureThreshold: 40
+  # This prevents 'empty index.yaml' file corruption issues when multiple helm dependency build processes try to write the same index.yaml file
+  # Setting this to false disables the shared working dir
+  # Ref: https://github.com/argoproj/argo-cd/issues/12902
+  # Ref: https://github.com/helm/helm/issues/10735#issuecomment-1486058169
+  useEphemeralHelmWorkingDir: false
 controller:
   readinessProbe:
     initialDelaySeconds: 0

--- a/argocd-config/values-override.yaml
+++ b/argocd-config/values-override.yaml
@@ -1,5 +1,13 @@
 # Overrides done by argocd-diff-preview
-# These will happen after the values.yaml file is loaded
+
+# This file is embedded by the argocd-diff-preview binary and will be loaded after the values.yaml file
+# If a values-override.yaml is placed in argocd-config directory when argocd-diff-preview runs,
+# contents will be loaded after this embedded config. Use with caution, if needing to override anything in this file
+#
+# Loading order:
+# - values.yaml            If present in argocd-config directory
+# - values-override.yaml   Embedded in argocd-diff-preview (this file)
+# - values-override.yaml   If present in argocd-config directory
 notifications:
   enabled: false
 dex:


### PR DESCRIPTION
This fixes the 'empty index.yaml' bug that surfaced after fixing #416 

When concurrent processes (helm dep build) share an ephemeral working dir, they can corrupt the resulting file.
Setting `useEphemeralHelmWorkingDir=false` has Helm use a unique temp. dir.

Rationale:
* Given ephemeral nature of the argocd setup in KinD, change in chart download efficiency would not persist anyway, so would be limited to single run
* Our testing showed no noticable slowdown on a ~280 applications run, but _did_ effectively remove the frequent corruption errors
* Is needed, users have the option to override the embedded config.

Regarding the last point: I added some clarifying comments to the embedded values-override.yaml.
Deliberately chose _not_ to add it to the docs, considering it an advanced use-case escape-hatch. (Adding to docs might just add complexity and confusion).