### PR TITLE
Fix | Show app rename with unchanged resources

### DIFF
--- a/integration-test/branch-1/target-1/output.html
+++ b/integration-test/branch-1/target-1/output.html
@@ -62,7 +62,8 @@ pre {
 <pre>Deleted (1):
 - folder2 (-19)
 
-Modified (2):
+Modified (3):
+± app1 -> app2
 ± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)</pre>
 
@@ -97,6 +98,15 @@ folder2 (examples/git-generator/app/app-set.yaml)
 	<tr class="removed_line"><td><pre>-        - containerPort: 80</pre></td></tr>
 </table>
 </div>
+
+</details>
+
+<details>
+<summary>
+app1 -&gt; app2 (examples/list-generator/app/app-set.yaml)
+</summary>
+
+<p><em>Application name changed, but rendered resources are unchanged</em></p>
 
 </details>
 

--- a/integration-test/branch-1/target-1/output.md
+++ b/integration-test/branch-1/target-1/output.md
@@ -5,7 +5,8 @@ Summary:
 Deleted (1):
 - folder2 (-19)
 
-Modified (2):
+Modified (3):
+± app1 -> app2
 ± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)
 ```
@@ -36,6 +37,14 @@ Modified (2):
 -        ports:
 -        - containerPort: 80
 ```
+</details>
+
+<details>
+<summary>app1 -> app2 (examples/list-generator/app/app-set.yaml)</summary>
+<br>
+
+_Application name changed, but rendered resources are unchanged_
+
 </details>
 
 <details>

--- a/integration-test/branch-1/target-2/output.html
+++ b/integration-test/branch-1/target-2/output.html
@@ -62,7 +62,8 @@ pre {
 <pre>Deleted (1):
 - folder2 (-19)
 
-Modified (1):
+Modified (2):
+± app1 -> app2
 ± multi-source-app (+1|-1)</pre>
 
 <div class="diffs">
@@ -96,6 +97,15 @@ folder2 (examples/git-generator/app/app-set.yaml)
 	<tr class="removed_line"><td><pre>-        - containerPort: 80</pre></td></tr>
 </table>
 </div>
+
+</details>
+
+<details>
+<summary>
+app1 -&gt; app2 (examples/list-generator/app/app-set.yaml)
+</summary>
+
+<p><em>Application name changed, but rendered resources are unchanged</em></p>
 
 </details>
 

--- a/integration-test/branch-1/target-2/output.md
+++ b/integration-test/branch-1/target-2/output.md
@@ -5,7 +5,8 @@ Summary:
 Deleted (1):
 - folder2 (-19)
 
-Modified (1):
+Modified (2):
+± app1 -> app2
 ± multi-source-app (+1|-1)
 ```
 
@@ -35,6 +36,14 @@ Modified (1):
 -        ports:
 -        - containerPort: 80
 ```
+</details>
+
+<details>
+<summary>app1 -> app2 (examples/list-generator/app/app-set.yaml)</summary>
+<br>
+
+_Application name changed, but rendered resources are unchanged_
+
 </details>
 
 <details>

--- a/integration-test/branch-1/target-3/output.html
+++ b/integration-test/branch-1/target-3/output.html
@@ -62,7 +62,8 @@ pre {
 <pre>Deleted (1):
 - folder2
 
-Modified (2):
+Modified (3):
+± app1 -> app2
 ± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)</pre>
 
@@ -73,6 +74,15 @@ folder2 [<a href="https://argocd.example.com/applications/folder2">link</a>] (ex
 </summary>
 
 <p><em>Diff hidden because <code>--hide-deleted-app-diff</code> is enabled</em></p>
+
+</details>
+
+<details>
+<summary>
+app1 -&gt; app2 [<a href="https://argocd.example.com/applications/app1">link</a>] (examples/list-generator/app/app-set.yaml)
+</summary>
+
+<p><em>Application name changed, but rendered resources are unchanged</em></p>
 
 </details>
 

--- a/integration-test/branch-1/target-3/output.md
+++ b/integration-test/branch-1/target-3/output.md
@@ -5,7 +5,8 @@ Summary:
 Deleted (1):
 - folder2
 
-Modified (2):
+Modified (3):
+± app1 -> app2
 ± multi-source-app (+2|-2)
 ± nginx-ingress (+1|-1)
 ```
@@ -15,6 +16,14 @@ Modified (2):
 <br>
 
 _Diff hidden because `--hide-deleted-app-diff` is enabled_
+
+</details>
+
+<details>
+<summary>app1 -> app2 [<a href="https://argocd.example.com/applications/app1">link</a>] (examples/list-generator/app/app-set.yaml)</summary>
+<br>
+
+_Application name changed, but rendered resources are unchanged_
 
 </details>
 

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -105,6 +105,8 @@ func emptyReasonHTML(reason matching.EmptyReason) string {
 		return "<p><em>Application rendered no resources</em></p>"
 	case matching.EmptyReasonHiddenDiff:
 		return "<p><em>Diff hidden because <code>--hide-deleted-app-diff</code> is enabled</em></p>"
+	case matching.EmptyReasonNameOnlyChange:
+		return "<p><em>Application name changed, but rendered resources are unchanged</em></p>"
 	default:
 		return "<p><em>Empty for unknown reason</em></p>"
 	}

--- a/pkg/diff/html_test.go
+++ b/pkg/diff/html_test.go
@@ -78,6 +78,21 @@ func TestHTMLSection_PrintHTMLSection_EmptyResources(t *testing.T) {
 	}
 }
 
+func TestHTMLSection_PrintHTMLSection_NameOnlyChange(t *testing.T) {
+	section := HTMLSection{
+		appName:     "old-app -> new-app",
+		filePath:    "path/to/app",
+		resources:   []ResourceSection{},
+		emptyReason: matching.EmptyReasonNameOnlyChange,
+	}
+
+	result := section.printHTMLSection()
+
+	if !strings.Contains(result, "Application name changed, but rendered resources are unchanged") {
+		t.Errorf("expected name-only change message, got:\n%s", result)
+	}
+}
+
 func TestHTMLSection_PrintHTMLSection_SkippedResource(t *testing.T) {
 	section := HTMLSection{
 		appName:  "my-app",

--- a/pkg/diff/markdown.go
+++ b/pkg/diff/markdown.go
@@ -23,6 +23,8 @@ func emptyReasonMarkdown(reason matching.EmptyReason) string {
 		return "_Application rendered no resources_"
 	case matching.EmptyReasonHiddenDiff:
 		return "_Diff hidden because `--hide-deleted-app-diff` is enabled_"
+	case matching.EmptyReasonNameOnlyChange:
+		return "_Application name changed, but rendered resources are unchanged_"
 	default:
 		return "_Empty for unknown reason_"
 	}

--- a/pkg/diff/markdown_test.go
+++ b/pkg/diff/markdown_test.go
@@ -373,6 +373,23 @@ func TestMarkdownSection_Build_EdgeCases(t *testing.T) {
 		}
 	})
 
+	t.Run("Name-only change", func(t *testing.T) {
+		section := MarkdownSection{
+			appName:     "old-app -> new-app",
+			filePath:    "path.yaml",
+			appURL:      "",
+			resources:   []ResourceSection{},
+			emptyReason: matching.EmptyReasonNameOnlyChange,
+		}
+		content, truncated := section.build(1000)
+		if truncated {
+			t.Errorf("Name-only change should not be truncated")
+		}
+		if !strings.Contains(content, "_Application name changed, but rendered resources are unchanged_") {
+			t.Errorf("Should contain name-only change explanation")
+		}
+	})
+
 	t.Run("Content with trailing newlines", func(t *testing.T) {
 		section := MarkdownSection{
 			appName:  "App",

--- a/pkg/matching/integration_test.go
+++ b/pkg/matching/integration_test.go
@@ -311,6 +311,86 @@ spec:
 	}
 }
 
+func TestGenerateAppDiffs_AppNameOnlyChange(t *testing.T) {
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 1`
+
+	baseApps := []extract.ExtractedApp{
+		makeAppFromYAML(t, "old-app-id", "old-app-name", deploymentYAML),
+	}
+	targetApps := []extract.ExtractedApp{
+		makeAppFromYAML(t, "new-app-id", "new-app-name", deploymentYAML),
+	}
+
+	diffs, err := GenerateAppDiffs(baseApps, targetApps, 3, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate app diffs: %v", err)
+	}
+
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 app diff for name-only change, got %d", len(diffs))
+	}
+
+	diff := diffs[0]
+	if diff.Action != ActionModified {
+		t.Fatalf("expected ActionModified, got %s", diff.Action)
+	}
+	if diff.PrettyName() != "old-app-name -> new-app-name" {
+		t.Fatalf("expected app rename in pretty name, got %q", diff.PrettyName())
+	}
+	if diff.EmptyReason != EmptyReasonNameOnlyChange {
+		t.Fatalf("expected EmptyReasonNameOnlyChange, got %d", diff.EmptyReason)
+	}
+	if len(diff.Resources) != 0 {
+		t.Fatalf("expected no resource diffs, got %d", len(diff.Resources))
+	}
+}
+
+func TestGenerateAppDiffs_AppIDOnlyChangeKeepsGeneratedSuffixHidden(t *testing.T) {
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 1`
+
+	baseApps := []extract.ExtractedApp{
+		makeAppFromYAML(t, "eks-hotel-a-nonprod-tenant-egmont-it-cpt-eso", "eks-hotel-a-nonprod-tenant-egmont-it-cpt-eso", deploymentYAML),
+	}
+	targetApps := []extract.ExtractedApp{
+		makeAppFromYAML(t, "eks-hotel-a-nonprod-eso-1", "eks-hotel-a-nonprod-eso", deploymentYAML),
+	}
+
+	diffs, err := GenerateAppDiffs(baseApps, targetApps, 3, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate app diffs: %v", err)
+	}
+
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 app diff for ID-only change, got %d", len(diffs))
+	}
+
+	diff := diffs[0]
+	if diff.Action != ActionModified {
+		t.Fatalf("expected ActionModified, got %s", diff.Action)
+	}
+	if diff.PrettyName() != "eks-hotel-a-nonprod-tenant-egmont-it-cpt-eso -> eks-hotel-a-nonprod-eso" {
+		t.Fatalf("expected app rename in pretty name, got %q", diff.PrettyName())
+	}
+	if strings.Contains(diff.PrettyName(), "-eso-1") {
+		t.Fatalf("expected generated ID suffix to stay hidden, got %q", diff.PrettyName())
+	}
+	if diff.EmptyReason != EmptyReasonNameOnlyChange {
+		t.Fatalf("expected EmptyReasonNameOnlyChange, got %d", diff.EmptyReason)
+	}
+}
+
 // TestFullFlow_UnchangedResourcesFiltered tests that identical resources don't appear in diff
 func TestFullFlow_UnchangedResourcesFiltered(t *testing.T) {
 	deploymentYAML := `apiVersion: apps/v1

--- a/pkg/matching/output.go
+++ b/pkg/matching/output.go
@@ -86,6 +86,7 @@ const (
 	EmptyReasonNone        EmptyReason = iota // not empty - has resources
 	EmptyReasonNoResources                    // application genuinely rendered no resources
 	EmptyReasonHiddenDiff                     // diff hidden by --hide-deleted-app-diff
+	EmptyReasonNameOnlyChange                 // application name changed, but rendered resources did not
 )
 
 // DiffAction represents the type of change
@@ -246,7 +247,11 @@ func generateAppDiff(pair Pair, contextLines uint, ignorePattern *regexp.Regexp,
 	// Added/deleted apps with zero resources should still be reported.
 	if len(changedResources) == 0 {
 		if diff.Action == ActionModified {
-			diff.Action = ActionUnchanged
+			if diff.OldName != diff.NewName {
+				diff.EmptyReason = EmptyReasonNameOnlyChange
+			} else {
+				diff.Action = ActionUnchanged
+			}
 		} else {
 			diff.EmptyReason = EmptyReasonNoResources
 		}


### PR DESCRIPTION
## Summary
- Show applications as changed when only the application name changes
- Render a short message when resources are unchanged
- Update tests and branch-1 target-1 expected output

## Testing
- make go-build
- TEST_CASE=\"branch-1/target-1\" go test -v -timeout 10m -run TestSingleCase ./integration-test/... -update