### PR TITLE
Fix | Clean finalizers before stale app deletion

### DIFF
--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -11,17 +11,28 @@ import (
 	"github.com/dag-andersen/argocd-diff-preview/pkg/vars"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var argoCDApplicationResource = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+var argoCDApplicationFinalizers = map[string]bool{
+	"resources-finalizer.argocd.argoproj.io":            true,
+	"resources-finalizer.argocd.argoproj.io/background": true,
+	"resources-finalizer.argocd.argoproj.io/foreground": true,
+	"pre-delete-finalizer.argocd.argoproj.io":           true,
+	"pre-delete-finalizer.argocd.argoproj.io/cleanup":   true,
+	"post-delete-finalizer.argocd.argoproj.io":          true,
+	"post-delete-finalizer.argocd.argoproj.io/cleanup":  true,
+}
+
 // GetArgoCDApplication gets a single ArgoCD application by name
 func (c *Client) GetArgoCDApplication(namespace string, name string) (*v1alpha1.Application, error) {
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-
-	result, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	result, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +53,8 @@ func (c *Client) GetArgoCDApplication(namespace string, name string) (*v1alpha1.
 
 // SetArgoCDAppRefreshAnnotation sets the refresh annotation on an ArgoCD application to trigger a refresh
 func (c *Client) SetArgoCDAppRefreshAnnotation(namespace string, name string) error {
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-
 	// Get the current application
-	app, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	app, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get application %s: %w", name, err)
 	}
@@ -61,7 +70,7 @@ func (c *Client) SetArgoCDAppRefreshAnnotation(namespace string, name string) er
 	app.SetAnnotations(annotations)
 
 	// Update the application
-	_, err = c.clientSet.Resource(applicationRes).Namespace(namespace).Update(context.Background(), app, metav1.UpdateOptions{})
+	_, err = c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Update(context.Background(), app, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update application %s with refresh annotation: %w", name, err)
 	}
@@ -78,19 +87,16 @@ func (c *Client) DeleteArgoCDApplication(namespace string, name string) error {
 		return fmt.Errorf("no namespace provided")
 	}
 
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
 	if err := c.removeArgoCDApplicationFinalizers(namespace, name); err != nil {
 		return err
 	}
 
-	return c.clientSet.Resource(applicationRes).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	return c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }
 
 func (c *Client) removeArgoCDApplicationFinalizers(namespace string, name string) error {
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-
 	for attempt := 1; attempt <= 5; attempt++ {
-		app, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		app, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		}
@@ -98,21 +104,50 @@ func (c *Client) removeArgoCDApplicationFinalizers(namespace string, name string
 			return fmt.Errorf("failed to get application %s before deletion: %w", name, err)
 		}
 
-		if len(app.GetFinalizers()) == 0 {
-			return nil
+		removed, err := c.removeArgoCDApplicationFinalizersFromApp(namespace, app)
+		if err == nil || !errors.IsConflict(err) {
+			return err
 		}
-
-		patch := []byte(`{"metadata":{"finalizers":null}}`)
-		if _, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Patch(context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{}); err == nil {
+		if !removed {
 			return nil
-		} else if !errors.IsConflict(err) {
-			return fmt.Errorf("failed to remove finalizers from application %s before deletion: %w", name, err)
 		}
 
 		time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)
 	}
 
 	return fmt.Errorf("failed to remove finalizers from application %s before deletion: too many update conflicts", name)
+}
+
+func (c *Client) removeArgoCDApplicationFinalizersFromApp(namespace string, app *unstructured.Unstructured) (bool, error) {
+	appName := app.GetName()
+	currentFinalizers := app.GetFinalizers()
+	if len(currentFinalizers) == 0 {
+		return false, nil
+	}
+
+	log.Info().Msgf("Removing finalizers from application %s", appName)
+
+	patch := []byte(`{"metadata":{"finalizers":null}}`)
+	if _, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Patch(context.Background(), appName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		if errors.IsConflict(err) {
+			return true, err
+		}
+
+		return true, fmt.Errorf("failed to remove finalizers from application %s before deletion: %w", appName, err)
+	}
+
+	log.Info().Msgf("Removed finalizers from application %s", appName)
+	return true, nil
+}
+
+func hasArgoCDApplicationFinalizer(app *unstructured.Unstructured) bool {
+	for _, finalizer := range app.GetFinalizers() {
+		if argoCDApplicationFinalizers[finalizer] {
+			return true
+		}
+	}
+
+	return false
 }
 
 // DeleteAllApplicationsOlderThan deletes all ArgoCD applications older than a given number of minutes
@@ -127,8 +162,7 @@ func (c *Client) DeleteAllApplicationsOlderThan(namespace string, minutes int) e
 		LabelSelector: vars.ArgoCDApplicationLabelKey,
 	}
 
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-	apps, err := c.clientSet.Resource(applicationRes).Namespace(namespace).List(context.Background(), listOptions)
+	apps, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).List(context.Background(), listOptions)
 	if err != nil {
 		return err
 	}
@@ -137,8 +171,11 @@ func (c *Client) DeleteAllApplicationsOlderThan(namespace string, minutes int) e
 		creationTimestamp := app.GetCreationTimestamp()
 		timeDiff := time.Since(creationTimestamp.Time)
 		if timeDiff.Minutes() > float64(minutes) {
-			err := c.DeleteArgoCDApplication(namespace, app.GetName())
-			if err != nil {
+			if _, err := c.removeArgoCDApplicationFinalizersFromApp(namespace, &app); err != nil {
+				return err
+			}
+
+			if err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Delete(context.Background(), app.GetName(), metav1.DeleteOptions{}); err != nil {
 				return err
 			}
 			deletedCount++
@@ -158,21 +195,18 @@ func (c *Client) DeleteArgoCDApplications(namespace string) error {
 
 	log.Info().Msg("Deleting applications")
 
-	// Remove obstructive finalizers
-	if err := c.RemoveObstructiveFinalizers(namespace); err != nil {
-		return fmt.Errorf("failed to remove obstructive finalizers: %w", err)
-	}
-
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-
-	apps, err := c.clientSet.Resource(applicationRes).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+	apps, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
 	for _, app := range apps.Items {
-		err := c.clientSet.Resource(applicationRes).Namespace(namespace).Delete(context.Background(), app.GetName(), metav1.DeleteOptions{})
-		if err != nil {
+		if _, err := c.removeArgoCDApplicationFinalizersFromApp(namespace, &app); err != nil {
+			log.Error().Err(err).Msgf("Failed to remove finalizers from application %s", app.GetName())
+			continue
+		}
+
+		if err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).Delete(context.Background(), app.GetName(), metav1.DeleteOptions{}); err != nil {
 			log.Error().Err(err).Msgf("Failed to delete application %s", app.GetName())
 		}
 	}
@@ -186,7 +220,7 @@ func (c *Client) DeleteArgoCDApplications(namespace string) error {
 		case <-ctx.Done():
 			return fmt.Errorf("timeout waiting for applications to be deleted")
 		default:
-			apps, err := c.clientSet.Resource(applicationRes).Namespace(namespace).List(ctx, metav1.ListOptions{})
+			apps, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return err
 			}
@@ -205,62 +239,21 @@ func (c *Client) DeleteArgoCDApplications(namespace string) error {
 
 // RemoveObstructiveFinalizers removes finalizers from applications that would prevent deletion
 func (c *Client) RemoveObstructiveFinalizers(namespace string) error {
-
-	// List of obstructiveFinalizers that prevent deletion of applications
-	obstructiveFinalizers := []string{
-		"post-delete-finalizer.argocd.argoproj.io",
-		"post-delete-finalizer.argoproj.io/cleanup",
-	}
-
 	log.Debug().Msg("Removing obstructive finalizers from applications")
 
 	// Get ArgoCD applications
-	applicationRes := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
-	apps, err := c.clientSet.Resource(applicationRes).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+	apps, err := c.clientSet.Resource(argoCDApplicationResource).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list applications: %w", err)
 	}
 
 	for _, app := range apps.Items {
-		appName := app.GetName()
-		currentFinalizers := app.GetFinalizers()
-
-		if len(currentFinalizers) == 0 {
+		if !hasArgoCDApplicationFinalizer(&app) {
 			continue
 		}
 
-		// Create a map for faster lookup of obstructive finalizers
-		obstructiveMap := make(map[string]bool)
-		for _, f := range obstructiveFinalizers {
-			obstructiveMap[f] = true
-		}
-
-		// Check if any current finalizers are in our obstructive list
-		foundObstructive := false
-		for _, fin := range currentFinalizers {
-			if obstructiveMap[fin] {
-				foundObstructive = true
-				break
-			}
-		}
-
-		if !foundObstructive {
-			continue
-		}
-
-		log.Info().Msgf("Removing obstructive finalizers from application %s", appName)
-
-		app.SetFinalizers(nil)
-		_, err := c.clientSet.Resource(applicationRes).Namespace(namespace).Update(
-			context.Background(),
-			&app,
-			metav1.UpdateOptions{},
-		)
-
-		if err != nil {
-			log.Error().Err(err).Msgf("Failed to update finalizers for application %s", appName)
-		} else {
-			log.Info().Msgf("Removed finalizers from application %s", appName)
+		if _, err := c.removeArgoCDApplicationFinalizersFromApp(namespace, &app); err != nil {
+			log.Error().Err(err).Msgf("Failed to remove finalizers from application %s", app.GetName())
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Clean all known Argo CD application finalizers before deleting stale preview apps
- Share finalizer cleanup logic between single-app and batch deletion paths
- Avoid extra GET calls in batch cleanup by using already-listed application objects

## Testing
- `make run-unit-tests`