### PR TITLE
Fix | Render same-repo refs with remote Helm charts

### DIFF
--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -445,7 +445,7 @@ func renderAppWithChildDiscovery(
 	apiVersions []string,
 	redirectRevisions []string,
 ) ([]unstructured.Unstructured, []argoapplication.ArgoResource, error) {
-	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions)
+	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions, helmChartPuller{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/reposerverextract/chartpull.go
+++ b/pkg/reposerverextract/chartpull.go
@@ -1,0 +1,188 @@
+package reposerverextract
+
+// chartpull.go - pulling remote Helm charts to a local directory.
+//
+// Some multi-source Applications use a remote Helm chart (an external Helm
+// registry, HTTP or OCI) whose value files come from a $ref source that lives
+// in the same repository as the pull request (e.g. cert-manager + an
+// envs/<env>/values.yaml file checked out from the PR branch).
+//
+// The repo server's file-streaming RPC (GenerateManifestWithFiles) resolves the
+// chart from the streamed tarball and never pulls it from a registry. To render
+// such an Application with the PR's local value files we therefore pull the
+// remote chart ourselves and place it inside the streamed tree alongside the
+// ref directories. From there the repo server renders it as an ordinary local
+// path chart. See buildManifestRequestForSource for how the result is used.
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/rs/zerolog/log"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
+)
+
+// chartPuller fetches a remote Helm chart and extracts it into destDir,
+// returning the path to the extracted chart directory (the directory that
+// contains Chart.yaml). Implementations must place all chart files under
+// destDir so the caller can stream them to the repo server.
+type chartPuller interface {
+	Pull(source v1alpha1.ApplicationSource, creds *RepoCreds, destDir string) (chartDir string, err error)
+}
+
+// helmChartPuller is the production chartPuller. It uses the Helm SDK's pull
+// action to download and untar a chart from an HTTP(S) or OCI Helm registry.
+// It is stateless, so a zero value is safe to use concurrently (each Pull call
+// works in its own destDir with an isolated Helm configuration).
+type helmChartPuller struct{}
+
+// Pull downloads source.Chart at source.TargetRevision from source.RepoURL and
+// untars it under destDir. Credentials for the chart registry are looked up in
+// creds (which may be nil for public registries).
+func (helmChartPuller) Pull(source v1alpha1.ApplicationSource, creds *RepoCreds, destDir string) (string, error) {
+	if source.Chart == "" {
+		return "", fmt.Errorf("application source has no chart to pull (repoURL %q)", source.RepoURL)
+	}
+
+	// Isolate the Helm configuration (repositories.yaml, registry config, index
+	// cache) inside destDir so we never read or mutate the user's ~/.config/helm
+	// or ~/.cache/helm.
+	helmHome := filepath.Join(destDir, ".helm")
+	if err := os.MkdirAll(helmHome, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create helm home: %w", err)
+	}
+	settings := cli.New()
+	settings.RepositoryConfig = filepath.Join(helmHome, "repositories.yaml")
+	settings.RepositoryCache = filepath.Join(helmHome, "cache")
+	settings.RegistryConfig = filepath.Join(helmHome, "registry-config.json")
+
+	repo := creds.GetRepo(source.RepoURL)
+
+	untarDir := filepath.Join(destDir, "chart")
+	if err := os.MkdirAll(untarDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create chart dir: %w", err)
+	}
+
+	actionConfig := &action.Configuration{}
+	pull := action.NewPullWithOpts(action.WithConfig(actionConfig))
+	pull.Settings = settings
+	pull.Version = source.TargetRevision
+	pull.Username = repo.Username
+	pull.Password = repo.Password
+	pull.Untar = true
+	pull.DestDir = untarDir
+	pull.UntarDir = untarDir
+
+	chartRef := source.Chart
+	if sourceIsOCI(&source) {
+		registryClient, err := registry.NewClient(
+			registry.ClientOptDebug(settings.Debug),
+			registry.ClientOptWriter(io.Discard),
+			registry.ClientOptCredentialsFile(settings.RegistryConfig),
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to create OCI registry client: %w", err)
+		}
+		actionConfig.RegistryClient = registryClient
+		pull.SetRegistryClient(registryClient)
+
+		if repo.Username != "" && repo.Password != "" {
+			host := ociRegistryHost(source.RepoURL)
+			log.Debug().Str("registry", host).Msg("Logging in to OCI registry to pull chart")
+			if err := registryClient.Login(host,
+				registry.LoginOptBasicAuth(repo.Username, repo.Password),
+			); err != nil {
+				return "", fmt.Errorf("failed to log in to OCI registry %s: %w", host, err)
+			}
+		}
+		chartRef = ociChartRef(source.RepoURL, source.Chart)
+	} else {
+		// Classic HTTP(S) repository: the pull action resolves the chart through
+		// the repo index when RepoURL is set, so no repositories.yaml entry is
+		// required up front.
+		pull.RepoURL = source.RepoURL
+	}
+
+	log.Debug().
+		Str("chart", source.Chart).
+		Str("repoURL", source.RepoURL).
+		Str("version", source.TargetRevision).
+		Msg("Pulling remote Helm chart for local rendering")
+
+	if out, err := pull.Run(chartRef); err != nil {
+		return "", fmt.Errorf("failed to pull chart %q from %q (version %q): %w: %s",
+			source.Chart, source.RepoURL, source.TargetRevision, err, strings.TrimSpace(out))
+	}
+
+	chartDir, err := findChartDir(untarDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to locate pulled chart %q: %w", source.Chart, err)
+	}
+	return chartDir, nil
+}
+
+// findChartDir returns the directory under root that contains a Chart.yaml.
+// helm pull --untar expands the chart into a subdirectory named after the
+// chart, so the common case is a single child directory. A recursive walk is
+// used as a fallback for unusual layouts.
+func findChartDir(root string) (string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, e.Name())
+		if _, statErr := os.Stat(filepath.Join(candidate, "Chart.yaml")); statErr == nil {
+			return candidate, nil
+		}
+	}
+
+	var found string
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == "Chart.yaml" {
+			found = filepath.Dir(path)
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return "", walkErr
+	}
+	if found != "" {
+		return found, nil
+	}
+	return "", fmt.Errorf("no Chart.yaml found under %s after pulling chart", root)
+}
+
+// ociChartRef builds an oci:// chart reference from an Argo CD OCI Helm source,
+// where repoURL is the registry/repository base and chart is the chart name,
+// e.g. ("ghcr.io/org/charts", "podinfo") -> "oci://ghcr.io/org/charts/podinfo".
+// A repoURL that already carries the oci:// scheme is preserved.
+func ociChartRef(repoURL, chart string) string {
+	base := strings.TrimSuffix(strings.TrimSpace(repoURL), "/")
+	base = "oci://" + strings.TrimPrefix(base, "oci://")
+	return base + "/" + chart
+}
+
+// ociRegistryHost extracts the registry host from an OCI repository URL,
+// e.g. "oci://ghcr.io/org/charts" or "ghcr.io/org/charts" -> "ghcr.io".
+func ociRegistryHost(repoURL string) string {
+	rest := strings.TrimPrefix(strings.TrimSpace(repoURL), "oci://")
+	if i := strings.Index(rest, "/"); i >= 0 {
+		rest = rest[:i]
+	}
+	return rest
+}

--- a/pkg/reposerverextract/chartpull.go
+++ b/pkg/reposerverextract/chartpull.go
@@ -4,12 +4,12 @@ package reposerverextract
 //
 // Some multi-source Applications use a remote Helm chart (an external Helm
 // registry, HTTP or OCI) whose value files come from a $ref source that lives
-// in the same repository as the pull request (e.g. cert-manager + an
-// envs/<env>/values.yaml file checked out from the PR branch).
+// in the same repository being compared (e.g. cert-manager + an
+// envs/<env>/values.yaml file checked out in the base or target branch folder).
 //
 // The repo server's file-streaming RPC (GenerateManifestWithFiles) resolves the
 // chart from the streamed tarball and never pulls it from a registry. To render
-// such an Application with the PR's local value files we therefore pull the
+// such an Application with the checked-out value files we therefore pull the
 // remote chart ourselves and place it inside the streamed tree alongside the
 // ref directories. From there the repo server renders it as an ordinary local
 // path chart. See buildManifestRequestForSource for how the result is used.

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -182,7 +182,7 @@ func RenderApplicationsFromBothBranches(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(remainingTime())*time.Second)
 			defer cancel()
 
-			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions)
+			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions, helmChartPuller{})
 			if err != nil {
 				results <- result{err: fmt.Errorf("failed to render app %s: %w", app.GetLongName(), err)}
 				return
@@ -259,6 +259,7 @@ func renderApp(
 	repoSelector *repository.Selector,
 	kubeVersion string,
 	apiVersions []string,
+	puller chartPuller,
 ) ([]unstructured.Unstructured, error) {
 	branchFolder, ok := branchFolderByType[app.Branch]
 	if !ok {
@@ -284,6 +285,7 @@ func renderApp(
 				repoSelector: repoSelector,
 				kubeVersion:  kubeVersion,
 				apiVersions:  apiVersions,
+				puller:       puller,
 			},
 		)
 		if err != nil {
@@ -522,6 +524,10 @@ type manifestRequestRenderContext struct {
 	repoSelector *repository.Selector
 	kubeVersion  string
 	apiVersions  []string
+	// puller fetches remote Helm charts so they can be streamed to the repo
+	// server together with same-repo $ref value files. When nil, remote charts
+	// with ref sources fall back to the unary GenerateManifest RPC.
+	puller chartPuller
 }
 
 func buildManifestRequestForSource(
@@ -618,13 +624,26 @@ func buildManifestRequestForSource(
 	//     - chart: cert-manager  repoURL: https://charts.jetstack.io  ← primary
 	//       helm.valueFiles: [$local/path/to/values.yaml]
 	//
-	// We cannot stream local files for a chart: source via GenerateManifestWithFiles
-	// because the repo server tries to read Chart.yaml from the tarball root and
-	// fails (the chart lives in an external registry, not in the tarball).
-	// Instead, use the unary GenerateManifest RPC and populate RefSources so the
-	// repo server fetches the ref content from its own git cache. The $ref/…
-	// value file paths are left unchanged (no rewriting needed).
+	// We cannot stream a chart: source for GenerateManifestWithFiles directly
+	// because the repo server reads Chart.yaml from the tarball root, which is
+	// empty (the chart lives in an external registry, not in the tarball).
+	//
+	// When every ref source lives in the PR repo (issue #441), the value files
+	// only exist on the locally checked-out branch. RedirectSources has pointed
+	// those refs at the working branch, which was never pushed, so the unary
+	// GenerateManifest RPC cannot fetch them. Instead we pull the chart locally
+	// and stream it alongside the ref directories (see
+	// buildRemoteChartLocalRefsRequest), rendering with the PR's value files.
+	//
+	// When a ref source lives in a different repository (issue #428), its files
+	// are not checked out locally, so we keep using the unary GenerateManifest
+	// RPC and populate RefSources so the repo server fetches the ref content
+	// from its own git cache.
 	if primarySource.Chart != "" {
+		if renderContext.puller != nil && !hasExternalRefSource(refSources, renderContext.repoSelector) {
+			return buildRemoteChartLocalRefsRequest(
+				app, primarySource, refSources, branchFolder, creds, renderContext.puller, newManifestRequest)
+		}
 		request = newManifestRequest(&primarySource)
 		request.RefSources = buildRefSourcesMap(refSources, creds)
 		return request, "", nil, nil
@@ -669,8 +688,97 @@ func buildManifestRequestForSource(
 		return nil, "", nil, fmt.Errorf("failed to copy content source dir %q: %w", srcContentDir, err)
 	}
 
-	// Copy each ref source and build a ref name → local-path mapping.
-	refDirs := make(map[string]string) // ref name → absolute path inside tempDir
+	// Copy each ref source into <tempDir>/.refs/<refName>/.
+	refDirs, err := stageRefSources(tempDir, branchFolder, refSources)
+	if err != nil {
+		cleanup()
+		return nil, "", nil, err
+	}
+
+	// Rewrite $ref/… value-file paths to paths relative to the content dir.
+	appDirAbs := filepath.Join(tempDir, primarySource.Path)
+	rewrittenSource, err := rewriteRefValueFiles(primarySource, appDirAbs, refDirs, app.GetLongName())
+	if err != nil {
+		cleanup()
+		return nil, "", nil, err
+	}
+
+	request = newManifestRequest(&rewrittenSource)
+	return request, tempDir, cleanup, nil
+}
+
+// buildRemoteChartLocalRefsRequest renders a multi-source Application whose
+// primary source is a remote Helm chart and whose $ref value files all come
+// from the PR repository (issue #441). The remote chart is pulled into a temp
+// directory and streamed to the repo server together with the ref directories,
+// so the render uses the value files from the locally checked-out branch.
+//
+// The returned streamDir must be cleaned up by the caller via cleanup once the
+// repo server RPC completes.
+func buildRemoteChartLocalRefsRequest(
+	app argoapplication.ArgoResource,
+	primarySource v1alpha1.ApplicationSource,
+	refSources []v1alpha1.ApplicationSource,
+	branchFolder string,
+	creds *RepoCreds,
+	puller chartPuller,
+	newManifestRequest func(*v1alpha1.ApplicationSource) *repoapiclient.ManifestRequest,
+) (request *repoapiclient.ManifestRequest, streamDir string, cleanup func(), err error) {
+	tempDir, err := os.MkdirTemp("", "argocd-diff-preview-chart-*")
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	cleanup = func() {
+		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+			log.Warn().Err(removeErr).Str("dir", tempDir).Msg("Failed to remove temp dir")
+		}
+	}
+
+	// Pull the remote chart into the streamed tree.
+	chartDir, err := puller.Pull(primarySource, creds, tempDir)
+	if err != nil {
+		cleanup()
+		return nil, "", nil, fmt.Errorf("failed to pull chart for app %s: %w", app.GetLongName(), err)
+	}
+
+	// Stage the same-repo ref sources next to the chart.
+	refDirs, err := stageRefSources(tempDir, branchFolder, refSources)
+	if err != nil {
+		cleanup()
+		return nil, "", nil, err
+	}
+
+	// Render the pulled chart as a local path chart: clear Chart, point Path at
+	// the extracted chart directory, and adopt the PR repository URL (the refs
+	// are same-repo, so they identify it) instead of the chart registry URL.
+	rewrittenSource := primarySource
+	rewrittenSource.Chart = ""
+	relChartPath, err := filepath.Rel(tempDir, chartDir)
+	if err != nil {
+		cleanup()
+		return nil, "", nil, fmt.Errorf("failed to compute chart path: %w", err)
+	}
+	rewrittenSource.Path = relChartPath
+	if len(refSources) > 0 {
+		rewrittenSource.RepoURL = refSources[0].RepoURL
+	}
+
+	// Rewrite $ref/… value-file paths to paths relative to the chart directory.
+	rewrittenSource, err = rewriteRefValueFiles(rewrittenSource, chartDir, refDirs, app.GetLongName())
+	if err != nil {
+		cleanup()
+		return nil, "", nil, err
+	}
+
+	return newManifestRequest(&rewrittenSource), tempDir, cleanup, nil
+}
+
+// stageRefSources copies each ref source's directory into
+// <tempDir>/.refs/<refName>/ and returns a map of ref name to absolute local
+// directory. A ref source with an empty Path points at the repository root
+// (branchFolder).
+func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.ApplicationSource) (map[string]string, error) {
+	refDirs := make(map[string]string, len(refSources))
 	for _, ref := range refSources {
 		refDir := filepath.Join(tempDir, ".refs", ref.Ref)
 		srcRefDir := filepath.Join(branchFolder, ref.Path)
@@ -679,46 +787,52 @@ func buildManifestRequestForSource(
 			srcRefDir = branchFolder
 		}
 		if err := copyDir(srcRefDir, refDir); err != nil {
-			cleanup()
-			return nil, "", nil, fmt.Errorf("failed to copy ref source %q: %w", ref.Ref, err)
+			return nil, fmt.Errorf("failed to copy ref source %q: %w", ref.Ref, err)
 		}
 		refDirs[ref.Ref] = refDir
 	}
+	return refDirs, nil
+}
 
-	// ── Rewrite $ref/… paths in Helm ValueFiles to relative paths ─────────────
-	rewrittenSource := primarySource
-	if rewrittenSource.Helm != nil {
-		rewritten := make([]string, len(rewrittenSource.Helm.ValueFiles))
-		copy(rewritten, rewrittenSource.Helm.ValueFiles)
-		appDirAbs := filepath.Join(tempDir, primarySource.Path)
-		for i, vf := range rewritten {
-			if !strings.HasPrefix(vf, "$") {
-				continue
-			}
-			refName, refPath, ok := splitRefPath(vf)
-			if !ok {
-				continue
-			}
-			refLocalDir, known := refDirs[refName]
-			if !known {
-				cleanup()
-				return nil, "", nil, fmt.Errorf("value file %q references unknown ref %q in app %s", vf, refName, app.GetLongName())
-			}
-			absTarget := filepath.Join(refLocalDir, refPath)
-			relPath, err := filepath.Rel(appDirAbs, absTarget)
-			if err != nil {
-				cleanup()
-				return nil, "", nil, fmt.Errorf("failed to compute relative path for ref value file: %w", err)
-			}
-			rewritten[i] = relPath
-		}
-		helmCopy := *rewrittenSource.Helm
-		helmCopy.ValueFiles = rewritten
-		rewrittenSource.Helm = &helmCopy
+// rewriteRefValueFiles returns a copy of source whose Helm $ref/… value-file
+// paths are rewritten to filesystem paths relative to appDirAbs, resolved
+// against the staged ref directories in refDirs. Non-$ref value files are left
+// untouched, and a source with no Helm config is returned unchanged. The
+// returned source carries a fresh Helm copy, so the caller's source is not
+// mutated.
+func rewriteRefValueFiles(
+	source v1alpha1.ApplicationSource,
+	appDirAbs string,
+	refDirs map[string]string,
+	appLongName string,
+) (v1alpha1.ApplicationSource, error) {
+	if source.Helm == nil {
+		return source, nil
 	}
-
-	request = newManifestRequest(&rewrittenSource)
-	return request, tempDir, cleanup, nil
+	rewritten := make([]string, len(source.Helm.ValueFiles))
+	copy(rewritten, source.Helm.ValueFiles)
+	for i, vf := range rewritten {
+		if !strings.HasPrefix(vf, "$") {
+			continue
+		}
+		refName, refPath, ok := splitRefPath(vf)
+		if !ok {
+			continue
+		}
+		refLocalDir, known := refDirs[refName]
+		if !known {
+			return source, fmt.Errorf("value file %q references unknown ref %q in app %s", vf, refName, appLongName)
+		}
+		relPath, err := filepath.Rel(appDirAbs, filepath.Join(refLocalDir, refPath))
+		if err != nil {
+			return source, fmt.Errorf("failed to compute relative path for ref value file: %w", err)
+		}
+		rewritten[i] = relPath
+	}
+	helmCopy := *source.Helm
+	helmCopy.ValueFiles = rewritten
+	source.Helm = &helmCopy
+	return source, nil
 }
 
 func buildStreamDirForLocalSource(branchFolder string, source v1alpha1.ApplicationSource) (streamDir string, cleanup func(), err error) {

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -629,11 +629,13 @@ func buildManifestRequestForSource(
 	// empty (the chart lives in an external registry, not in the tarball).
 	//
 	// When every ref source lives in the PR repo (issue #441), the value files
-	// only exist on the locally checked-out branch. RedirectSources has pointed
-	// those refs at the working branch, which was never pushed, so the unary
-	// GenerateManifest RPC cannot fetch them. Instead we pull the chart locally
-	// and stream it alongside the ref directories (see
-	// buildRemoteChartLocalRefsRequest), rendering with the PR's value files.
+	// must come from the local base/target checkout so the diff reflects exactly
+	// what this run is comparing. The unary GenerateManifest RPC would make the
+	// repo server resolve those refs by fetching from the remote git repository,
+	// bypassing the local checkout and risking missing local or not-yet-fetched
+	// changes. Instead we pull the chart locally and stream it alongside the ref
+	// directories (see buildRemoteChartLocalRefsRequest), rendering with the
+	// checked-out value files.
 	//
 	// When a ref source lives in a different repository (issue #428), its files
 	// are not checked out locally, so we keep using the unary GenerateManifest

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -1266,6 +1266,183 @@ func compressAndListEntries(t *testing.T, dir string) []string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// 11. BUG #441: remote Helm chart whose value files come from a $ref source in
+//     the SAME repo as the PR.
+//
+//	https://github.com/dag-andersen/argocd-diff-preview/issues/441
+//
+//	sources:
+//	  - repoURL: https://github.com/org/charts.git   ← ref source, SAME repo as --repo
+//	    ref: values
+//	    targetRevision: main
+//	  - chart: cert-manager                          ← primary (REMOTE registry chart)
+//	    repoURL: https://charts.jetstack.io
+//	    targetRevision: v1.14.5
+//	    helm:
+//	      valueFiles:
+//	        - $values/envs/prod/values.yaml
+//
+// The pipeline runs RedirectSources BEFORE buildManifestRequestForSource.
+// RedirectSources rewrites the same-repo ref source's targetRevision from
+// "main" to the local working branch "pr" (that branch only exists on disk in
+// the checked-out branch folder; it was never pushed to the remote).
+//
+// buildManifestRequestForSource then hits the `primarySource.Chart != ""`
+// short-circuit in extract.go and routes to the REMOTE GenerateManifest RPC,
+// populating RefSources with {Repo: github.com/org/charts.git, TargetRevision: "pr"}.
+// The repo server then tries to `git fetch pr` from the REMOTE
+// github.com/org/charts.git - but "pr" does not exist there - so the render
+// fails and aborts the whole env.
+//
+// This test CHARACTERISES the current (buggy) routing. When the fix lands
+// (pull the remote chart and stream it together with the local $ref files via
+// GenerateManifestWithFiles) the assertions marked BUG below must be inverted:
+// streamDir must be non-empty (local streaming) so the $values files come from
+// the checked-out PR branch, not from the remote.
+// ─────────────────────────────────────────────────────────────────────────────
+func TestBuildManifestRequest_Issue441_SameRepoRefWithRemoteChart(t *testing.T) {
+	prRepo := "org/charts"
+	branchFolder := t.TempDir() // contents irrelevant on the (buggy) remote-RPC path
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-prod
+spec:
+  destination:
+    namespace: cert-manager
+  sources:
+    - repoURL: https://github.com/org/charts.git
+      ref: values
+      targetRevision: main
+    - repoURL: https://charts.jetstack.io
+      chart: cert-manager
+      targetRevision: v1.14.5
+      helm:
+        valueFiles:
+          - $values/envs/prod/values.yaml
+`)
+
+	selector := testRepoSelector(t, prRepo)
+
+	// Reproduce the real pipeline ordering: RedirectSources runs first and
+	// rewrites the same-repo ref source from "main" to the working branch "pr".
+	require.NoError(t, app.RedirectSources(selector, "pr", []string{"main"}))
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1, "only the chart source is a content source")
+	require.Len(t, refSources, 1)
+
+	// Sanity: RedirectSources rewrote the same-repo ref to "pr" but left the
+	// remote chart's targetRevision untouched.
+	require.Equal(t, "pr", refSources[0].TargetRevision,
+		"RedirectSources must rewrite the same-repo ref to the working branch")
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(
+		app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil,
+		manifestRequestRenderContext{repoSelector: selector})
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// ── Current (BUGGY) behaviour pinned by this characterization test ───────
+	//
+	// BUG #441: the chart short-circuit routes a SAME-repo ref to the remote
+	// RPC. After the fix this must become a LOCAL stream (streamDir != "").
+	assert.Empty(t, streamDir,
+		"BUG #441: same-repo $ref with a remote chart currently uses the remote RPC; "+
+			"after the fix it must stream the checked-out PR branch instead")
+
+	require.NotNil(t, req.RefSources)
+	refTarget, ok := req.RefSources["$values"]
+	require.True(t, ok, "RefSources must contain '$values'")
+
+	// BUG #441: the ref is pointed at the REMOTE repo with the local-only "pr"
+	// branch. The repo server cannot `git fetch pr` from the remote because that
+	// branch was never pushed - this is the exact failure reported in the issue.
+	assert.Equal(t, "https://github.com/org/charts.git", refTarget.Repo.Repo,
+		"BUG #441: same-repo ref is sent to the remote repo instead of being read locally")
+	assert.Equal(t, "pr", refTarget.TargetRevision,
+		"BUG #441: the remote RPC is asked to fetch the local-only working branch 'pr', "+
+			"which does not exist on the remote - this is why issue #441 fails")
+	assertDefaultProjectFields(t, req)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 12. GUARD (issue #428): remote Helm chart whose value files come from a $ref
+//     source in a DIFFERENT repo than the PR.
+//
+// This is the case #428 fixed and it is CORRECT today: an external ref is not
+// checked out locally, so the repo server must fetch it itself via the remote
+// RPC, using the ref's real remote targetRevision (NOT rewritten - the source
+// lives outside the PR repo, so RedirectSources leaves it alone).
+//
+// The #441 fix must keep this behaviour intact: only SAME-repo refs should
+// switch to local streaming; external refs must stay on the remote RPC. This
+// test guards against the fix over-reaching and regressing #428.
+// ─────────────────────────────────────────────────────────────────────────────
+func TestBuildManifestRequest_ExternalRefWithRemoteChart_StaysRemote(t *testing.T) {
+	prRepo := "org/charts"
+	branchFolder := t.TempDir()
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-prod
+spec:
+  destination:
+    namespace: cert-manager
+  sources:
+    - repoURL: https://github.com/other-org/app-values.git
+      ref: values
+      targetRevision: main
+    - repoURL: https://charts.jetstack.io
+      chart: cert-manager
+      targetRevision: v1.14.5
+      helm:
+        valueFiles:
+          - $values/envs/prod/values.yaml
+`)
+
+	selector := testRepoSelector(t, prRepo)
+
+	// RedirectSources must leave the external ref alone (different repo).
+	require.NoError(t, app.RedirectSources(selector, "pr", []string{"main"}))
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+	require.Len(t, refSources, 1)
+
+	require.Equal(t, "main", refSources[0].TargetRevision,
+		"external ref must NOT be redirected - it lives outside the PR repo")
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(
+		app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil,
+		manifestRequestRenderContext{repoSelector: selector})
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// Correct behaviour that must NOT regress when #441 is fixed: external ref
+	// stays on the remote RPC with its real remote targetRevision.
+	assert.Empty(t, streamDir,
+		"external $ref with a remote chart must keep using the remote RPC")
+	require.NotNil(t, req.RefSources)
+	refTarget, ok := req.RefSources["$values"]
+	require.True(t, ok, "RefSources must contain '$values'")
+	assert.Equal(t, "https://github.com/other-org/app-values.git", refTarget.Repo.Repo)
+	assert.Equal(t, "main", refTarget.TargetRevision,
+		"external ref must keep its real remote revision so the repo server can fetch it")
+	assertDefaultProjectFields(t, req)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // collectRepoURLs
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sort"
 	"testing"
 
@@ -84,6 +85,38 @@ func testRepoSelector(t *testing.T, repo string) *repository.Selector {
 	selector, err := repository.NewSelector(repo, "")
 	require.NoError(t, err)
 	return selector
+}
+
+// fakeChartPuller is a chartPuller test double that writes a minimal chart to
+// disk instead of contacting a Helm registry, so buildManifestRequestForSource
+// can be exercised without network access. It records the sources it is asked
+// to pull.
+type fakeChartPuller struct {
+	// files maps chart-relative paths to file contents. When nil, a minimal
+	// Chart.yaml is written so the streamed chart directory is valid.
+	files  map[string]string
+	pulled []v1alpha1.ApplicationSource
+}
+
+func (f *fakeChartPuller) Pull(source v1alpha1.ApplicationSource, _ *RepoCreds, destDir string) (string, error) {
+	f.pulled = append(f.pulled, source)
+	chartDir := filepath.Join(destDir, "chart", source.Chart)
+	files := f.files
+	if files == nil {
+		files = map[string]string{
+			"Chart.yaml": "apiVersion: v2\nname: " + source.Chart + "\nversion: 0.0.0\n",
+		}
+	}
+	for rel, content := range files {
+		full := filepath.Join(chartDir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			return "", err
+		}
+	}
+	return chartDir, nil
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1266,21 +1299,22 @@ func compressAndListEntries(t *testing.T, dir string) []string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 11. BUG #441: remote Helm chart whose value files come from a $ref source in
+//
+//  11. BUG #441: remote Helm chart whose value files come from a $ref source in
 //     the SAME repo as the PR.
 //
-//	https://github.com/dag-andersen/argocd-diff-preview/issues/441
+//     https://github.com/dag-andersen/argocd-diff-preview/issues/441
 //
-//	sources:
-//	  - repoURL: https://github.com/org/charts.git   ← ref source, SAME repo as --repo
-//	    ref: values
-//	    targetRevision: main
-//	  - chart: cert-manager                          ← primary (REMOTE registry chart)
-//	    repoURL: https://charts.jetstack.io
-//	    targetRevision: v1.14.5
-//	    helm:
-//	      valueFiles:
-//	        - $values/envs/prod/values.yaml
+//     sources:
+//     - repoURL: https://github.com/org/charts.git   ← ref source, SAME repo as --repo
+//     ref: values
+//     targetRevision: main
+//     - chart: cert-manager                          ← primary (REMOTE registry chart)
+//     repoURL: https://charts.jetstack.io
+//     targetRevision: v1.14.5
+//     helm:
+//     valueFiles:
+//     - $values/envs/prod/values.yaml
 //
 // The pipeline runs RedirectSources BEFORE buildManifestRequestForSource.
 // RedirectSources rewrites the same-repo ref source's targetRevision from
@@ -1302,7 +1336,14 @@ func compressAndListEntries(t *testing.T, dir string) []string {
 // ─────────────────────────────────────────────────────────────────────────────
 func TestBuildManifestRequest_Issue441_SameRepoRefWithRemoteChart(t *testing.T) {
 	prRepo := "org/charts"
-	branchFolder := t.TempDir() // contents irrelevant on the (buggy) remote-RPC path
+
+	// The PR branch is checked out locally and holds the value file the chart
+	// reads via $values. The ref source has no path, so it points at the repo
+	// root and the value file resolves under it.
+	branchFolder := t.TempDir()
+	stagedSrc := filepath.Join(branchFolder, "envs", "prod", "values.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stagedSrc), 0o755))
+	require.NoError(t, os.WriteFile(stagedSrc, []byte("replicaCount: 2\n"), 0o644))
 
 	app := makeApp(t, `
 apiVersion: argoproj.io/v1alpha1
@@ -1340,39 +1381,46 @@ spec:
 	require.Equal(t, "pr", refSources[0].TargetRevision,
 		"RedirectSources must rewrite the same-repo ref to the working branch")
 
+	puller := &fakeChartPuller{}
 	req, streamDir, cleanup, err := buildManifestRequestForSource(
 		app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil,
-		manifestRequestRenderContext{repoSelector: selector})
+		manifestRequestRenderContext{repoSelector: selector, puller: puller})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
 	}
 
-	// ── Current (BUGGY) behaviour pinned by this characterization test ───────
-	//
-	// BUG #441: the chart short-circuit routes a SAME-repo ref to the remote
-	// RPC. After the fix this must become a LOCAL stream (streamDir != "").
-	assert.Empty(t, streamDir,
-		"BUG #441: same-repo $ref with a remote chart currently uses the remote RPC; "+
-			"after the fix it must stream the checked-out PR branch instead")
+	// Fixed behaviour: same-repo refs with a remote chart use local streaming so
+	// the value files come from the checked-out PR branch, not from a remote git
+	// fetch of the local-only branch name.
+	require.NotEmpty(t, streamDir,
+		"same-repo $ref with a remote chart must stream the pulled chart plus local ref files")
+	assert.Nil(t, req.RefSources,
+		"local streaming rewrites $ref value files and must not ask repo-server to fetch refs remotely")
+	require.Len(t, puller.pulled, 1)
+	assert.Equal(t, "cert-manager", puller.pulled[0].Chart)
+	assert.Equal(t, "https://charts.jetstack.io", puller.pulled[0].RepoURL)
+	assert.Equal(t, "v1.14.5", puller.pulled[0].TargetRevision)
 
-	require.NotNil(t, req.RefSources)
-	refTarget, ok := req.RefSources["$values"]
-	require.True(t, ok, "RefSources must contain '$values'")
+	require.NotNil(t, req.ApplicationSource)
+	assert.Empty(t, req.ApplicationSource.Chart, "pulled chart must be rendered as a local path chart")
+	assert.Equal(t, "https://github.com/org/charts.git", req.ApplicationSource.RepoURL,
+		"streamed chart source should identify the PR repo, not the chart registry")
+	assert.NotEmpty(t, req.ApplicationSource.Path)
+	assert.FileExists(t, filepath.Join(streamDir, req.ApplicationSource.Path, "Chart.yaml"))
+	assert.FileExists(t, filepath.Join(streamDir, ".refs", "values", "envs", "prod", "values.yaml"))
 
-	// BUG #441: the ref is pointed at the REMOTE repo with the local-only "pr"
-	// branch. The repo server cannot `git fetch pr` from the remote because that
-	// branch was never pushed - this is the exact failure reported in the issue.
-	assert.Equal(t, "https://github.com/org/charts.git", refTarget.Repo.Repo,
-		"BUG #441: same-repo ref is sent to the remote repo instead of being read locally")
-	assert.Equal(t, "pr", refTarget.TargetRevision,
-		"BUG #441: the remote RPC is asked to fetch the local-only working branch 'pr', "+
-			"which does not exist on the remote - this is why issue #441 fails")
+	require.NotNil(t, req.ApplicationSource.Helm)
+	require.Len(t, req.ApplicationSource.Helm.ValueFiles, 1)
+	rewrittenValueFile := req.ApplicationSource.Helm.ValueFiles[0]
+	assert.False(t, strings.HasPrefix(rewrittenValueFile, "$"),
+		"$ref value file should be rewritten to a relative filesystem path")
+	assert.Contains(t, rewrittenValueFile, filepath.Join(".refs", "values", "envs", "prod", "values.yaml"))
 	assertDefaultProjectFields(t, req)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 12. GUARD (issue #428): remote Helm chart whose value files come from a $ref
+//  12. GUARD (issue #428): remote Helm chart whose value files come from a $ref
 //     source in a DIFFERENT repo than the PR.
 //
 // This is the case #428 fixed and it is CORRECT today: an external ref is not
@@ -1421,9 +1469,10 @@ spec:
 	require.Equal(t, "main", refSources[0].TargetRevision,
 		"external ref must NOT be redirected - it lives outside the PR repo")
 
+	puller := &fakeChartPuller{}
 	req, streamDir, cleanup, err := buildManifestRequestForSource(
 		app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil,
-		manifestRequestRenderContext{repoSelector: selector})
+		manifestRequestRenderContext{repoSelector: selector, puller: puller})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -1439,6 +1488,7 @@ spec:
 	assert.Equal(t, "https://github.com/other-org/app-values.git", refTarget.Repo.Repo)
 	assert.Equal(t, "main", refTarget.TargetRevision,
 		"external ref must keep its real remote revision so the repo server can fetch it")
+	assert.Empty(t, puller.pulled, "external refs must not trigger local chart pulling")
 	assertDefaultProjectFields(t, req)
 }
 

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -1317,22 +1317,22 @@ func compressAndListEntries(t *testing.T, dir string) []string {
 //     - $values/envs/prod/values.yaml
 //
 // The pipeline runs RedirectSources BEFORE buildManifestRequestForSource.
-// RedirectSources rewrites the same-repo ref source's targetRevision from
-// "main" to the local working branch "pr" (that branch only exists on disk in
-// the checked-out branch folder; it was never pushed to the remote).
+// RedirectSources rewrites same-repo sources from the configured remote
+// revision ("main" here) to the branch currently being rendered ("pr" here).
+// That is how the repo-server-api render path makes base/target comparisons
+// use the local branch folders passed to the tool.
 //
-// buildManifestRequestForSource then hits the `primarySource.Chart != ""`
-// short-circuit in extract.go and routes to the REMOTE GenerateManifest RPC,
-// populating RefSources with {Repo: github.com/org/charts.git, TargetRevision: "pr"}.
-// The repo server then tries to `git fetch pr` from the REMOTE
-// github.com/org/charts.git - but "pr" does not exist there - so the render
-// fails and aborts the whole env.
+// Before the fix, buildManifestRequestForSource treated every remote `chart:`
+// source as remote-only and returned streamDir="". That made repo-server fetch
+// the $values ref from the git remote instead of reading it from the local
+// branch folder. Depending on the environment, that could either fail during
+// git fetch or render stale/wrong values that do not match the checked-out
+// base/target files.
 //
-// This test CHARACTERISES the current (buggy) routing. When the fix lands
-// (pull the remote chart and stream it together with the local $ref files via
-// GenerateManifestWithFiles) the assertions marked BUG below must be inverted:
-// streamDir must be non-empty (local streaming) so the $values files come from
-// the checked-out PR branch, not from the remote.
+// Correct behaviour is to pull the remote chart locally, copy the same-repo ref
+// files from the checked-out branch into .refs, rewrite $values paths to
+// relative filesystem paths, and stream that complete temp tree with
+// GenerateManifestWithFiles.
 // ─────────────────────────────────────────────────────────────────────────────
 func TestBuildManifestRequest_Issue441_SameRepoRefWithRemoteChart(t *testing.T) {
 	prRepo := "org/charts"
@@ -1368,7 +1368,8 @@ spec:
 	selector := testRepoSelector(t, prRepo)
 
 	// Reproduce the real pipeline ordering: RedirectSources runs first and
-	// rewrites the same-repo ref source from "main" to the working branch "pr".
+	// rewrites the same-repo ref source from the configured revision ("main") to
+	// the branch currently being rendered ("pr").
 	require.NoError(t, app.RedirectSources(selector, "pr", []string{"main"}))
 
 	contentSources, refSources, hasMultipleSources, err := splitSources(app)
@@ -1376,8 +1377,8 @@ spec:
 	require.Len(t, contentSources, 1, "only the chart source is a content source")
 	require.Len(t, refSources, 1)
 
-	// Sanity: RedirectSources rewrote the same-repo ref to "pr" but left the
-	// remote chart's targetRevision untouched.
+	// Sanity: RedirectSources rewrote the same-repo ref to the rendered branch
+	// but left the remote chart's targetRevision untouched.
 	require.Equal(t, "pr", refSources[0].TargetRevision,
 		"RedirectSources must rewrite the same-repo ref to the working branch")
 
@@ -1391,8 +1392,8 @@ spec:
 	}
 
 	// Fixed behaviour: same-repo refs with a remote chart use local streaming so
-	// the value files come from the checked-out PR branch, not from a remote git
-	// fetch of the local-only branch name.
+	// the value files come from the checked-out branch folder, not from a remote
+	// git fetch performed by repo-server.
 	require.NotEmpty(t, streamDir,
 		"same-repo $ref with a remote chart must stream the pulled chart plus local ref files")
 	assert.Nil(t, req.RefSources,


### PR DESCRIPTION
## Summary
- Fix repo-server-api rendering for remote Helm charts whose `$ref` value files live in the same PR repository
- Pull the remote chart locally, stage same-repo refs under `.refs`, rewrite `$ref` value files to relative paths, and stream the temp tree to repo-server
- Keep external refs on the remote RPC path to preserve the existing issue #428 behavior

Closes #441

## Testing
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/reposerverextract/...`
- `make run-unit-tests`