### PR TITLE
feat: bundle k3d binary + explicit kubeconfig merge for --cluster=k3d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN go mod download
 RUN apt-get update && apt-get install -y curl
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-${TARGETARCH} && \
     chmod +x ./kind
+RUN curl -Lo ./k3d https://github.com/k3d-io/k3d/releases/download/v5.9.0/k3d-linux-${TARGETARCH} && \
+    chmod +x ./k3d
 
 # Copy source code - only what's needed
 COPY cmd/ ./cmd/
@@ -38,6 +40,7 @@ FROM gcr.io/distroless/static-debian12 AS final
 
 # Copy necessary binaries from the build stage
 COPY --from=build /argocd-diff-preview/kind /usr/local/bin/kind
+COPY --from=build /argocd-diff-preview/k3d /usr/local/bin/k3d
 COPY --from=build /argocd-diff-preview/argocd-diff-preview .
 
 # Copy docker from the docker image

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -60,6 +60,14 @@ func CreateCluster(clusterName, k3dOptions string, wait time.Duration) (time.Dur
 			log.Error().Msgf("❌ Failed to create cluster with options: %s", k3dOptions)
 		}
 		return time.Since(startTime), fmt.Errorf("failed to create cluster: %s", output)
+	} else {
+		log.Debug().Msgf("k3d cluster create output: %s", output)
+	}
+
+	// k3d's end-of-create kubeconfig merge is best-effort: on failure it only
+	// logs a warning and still exits 0. Merge explicitly so a failure surfaces.
+	if output, err := runCommand("k3d", "kubeconfig", "merge", clusterName, "--kubeconfig-merge-default"); err != nil {
+		return time.Since(startTime), fmt.Errorf("failed to write kubeconfig: %s", output)
 	}
 
 	duration := time.Since(startTime)


### PR DESCRIPTION
Two changes that make the existing `--cluster=k3d` option work reliably in the published image:

- **Bundle the `k3d` binary in the image.** The image shipped `kind` but not `k3d`, so `--cluster=k3d` failed out of the box. Adds the `k3d` binary alongside `kind` in the Dockerfile.
- **Explicit kubeconfig merge after `k3d cluster create`.** k3d's end-of-create kubeconfig merge is best-effort: on failure it only logs a warning and still exits 0, and its output was discarded. The tool then died later with a cryptic `No kubeconfig file found`. Running `k3d kubeconfig merge --kubeconfig-merge-default` explicitly surfaces the real error at the point of failure.

Split out of #452 per review.