### PR TITLE
Fix | Add missing .yaml extension to per-app manifest files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -449,7 +449,7 @@ func writeManifests(
 		if perApp {
 			// Always write the file, even if content is empty, so the user can see that
 			// an application existed but had no rendered output.
-			filePath := fmt.Sprintf("%s/%s", perAppFolder, app.Id)
+			filePath := fmt.Sprintf("%s/%s.yaml", perAppFolder, app.Id)
 			if err := utils.WriteFile(filePath, content); err != nil {
 				return fmt.Errorf("failed to write manifest for app %s: %w", app.Name, err)
 			}


### PR DESCRIPTION
## What
Adds the missing `.yaml` file extension when writing per-app manifest files.

Previously, in the `perApp` output mode, manifest files were written as:
`<perAppFolder>/<app.Id>`

They are now written as:
`<perAppFolder>/<app.Id>.yaml`

## Why
The per-app output files contain YAML manifests but were missing the `.yaml`
extension, making it harder for editors/tools to recognize the file type and
for users to identify the content at a glance.