### PR TITLE
Feat | Connect directly to argo-server and repo-server instead of port-forwarding

### DIFF
--- a/pkg/argocd/call_api.go
+++ b/pkg/argocd/call_api.go
@@ -58,7 +58,7 @@ func parseAPIError(body []byte, statusCode int) error {
 func (a *APIOperations) Login() error {
 
 	// Set up port forward to ArgoCD server
-	if err := a.portForwardToArgoCD(); err != nil {
+	if err := a.ensureConnection(); err != nil {
 		return fmt.Errorf("failed to set up port forward: %w", err)
 	}
 
@@ -218,7 +218,7 @@ func (a *APIOperations) verifyToken() error {
 // 3. It doesn't require the application to have been synced first
 func (a *APIOperations) GetManifests(appName string) ([]unstructured.Unstructured, bool, error) {
 	// Ensure port forward is active
-	if err := a.portForwardToArgoCD(); err != nil {
+	if err := a.ensureConnection(); err != nil {
 		return nil, false, err
 	}
 
@@ -325,7 +325,7 @@ func (a *APIOperations) GetManifests(appName string) ([]unstructured.Unstructure
 // The tempFolder parameter is not used in API mode but is required by the interface.
 func (a *APIOperations) AppsetGenerate(resource *unstructured.Unstructured, tempFolder string) ([]unstructured.Unstructured, error) {
 	// Ensure port forward is active
-	if err := a.portForwardToArgoCD(); err != nil {
+	if err := a.ensureConnection(); err != nil {
 		return nil, err
 	}
 
@@ -422,7 +422,7 @@ func (a *APIOperations) AppsetGenerate(resource *unstructured.Unstructured, temp
 // AddSourceNamespaceToDefaultAppProject adds "*" to the sourceNamespaces of the default AppProject
 func (a *APIOperations) AddSourceNamespaceToDefaultAppProject() error {
 	// Ensure port forward is active
-	if err := a.portForwardToArgoCD(); err != nil {
+	if err := a.ensureConnection(); err != nil {
 		return fmt.Errorf("failed to set up port forward: %w", err)
 	}
 
@@ -567,7 +567,7 @@ func getArgoCDLibVersion() string {
 // getServerVersion fetches the ArgoCD server version via the API
 func (a *APIOperations) getServerVersion() (string, error) {
 	// Ensure port forward is active
-	if err := a.portForwardToArgoCD(); err != nil {
+	if err := a.ensureConnection(); err != nil {
 		return "", fmt.Errorf("failed to set up port forward: %w", err)
 	}
 
@@ -611,6 +611,75 @@ func (a *APIOperations) getServerVersion() (string, error) {
 	}
 
 	return versionResponse.Version, nil
+}
+
+// argocdServerLabelSelector finds the Argo CD API server Service, mirroring the
+// repo server lookup in pkg/reposerver.
+const argocdServerLabelSelector = "app.kubernetes.io/part-of=argocd,app.kubernetes.io/component=server"
+
+// ensureConnection makes the Argo CD API server reachable. In-cluster runs address
+// its Service directly; everything else keeps the port-forward.
+//
+// The scheme has to be probed rather than derived from the Service: argocd-server
+// speaks TLS unless started with --insecure, and the chart maps BOTH the http and
+// the https Service port to the same container port either way — so the port name
+// says nothing about what the server actually speaks. Guessing wrong costs a full
+// client timeout (plain HTTP against a TLS listener just waits for a ClientHello),
+// which is far more expensive than one probe.
+func (a *APIOperations) ensureConnection() error {
+	connection := a.connection
+
+	connection.portForwardMutex.Lock()
+	if connection.serviceResolved {
+		connection.portForwardMutex.Unlock()
+		return nil
+	}
+	inCluster := a.k8sClient != nil && a.k8sClient.IsInCluster()
+	connection.portForwardMutex.Unlock()
+
+	if !inCluster {
+		return a.portForwardToArgoCD()
+	}
+
+	address, err := a.k8sClient.GetServiceAddressByLabel(a.namespace, argocdServerLabelSelector, "https", 443)
+	if err != nil {
+		return fmt.Errorf("failed to find Argo CD server service address (label: %s): %w", argocdServerLabelSelector, err)
+	}
+
+	url, err := probeAPIScheme(address)
+	if err != nil {
+		return err
+	}
+
+	connection.portForwardMutex.Lock()
+	connection.apiServerURL = url
+	connection.serviceResolved = true
+	connection.portForwardMutex.Unlock()
+
+	log.Debug().Str("url", url).Msg("Using Argo CD server service address")
+	return nil
+}
+
+// probeAPIScheme returns the base URL that answers, trying https before http.
+func probeAPIScheme(address string) (string, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed in-cluster cert
+		},
+	}
+	var lastErr error
+	for _, scheme := range []string{"https", "http"} {
+		url := fmt.Sprintf("%s://%s", scheme, address)
+		resp, err := client.Get(url + "/api/version")
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_ = resp.Body.Close()
+		return url, nil
+	}
+	return "", fmt.Errorf("Argo CD server at %s answered neither https nor http: %w", address, lastErr)
 }
 
 // portForwardToArgoCD sets up a port forward to the ArgoCD server if not already active

--- a/pkg/argocd/operations.go
+++ b/pkg/argocd/operations.go
@@ -57,7 +57,8 @@ type apiConnection struct {
 	portForwardActive    bool
 	portForwardMutex     sync.Mutex
 	portForwardStopChan  chan struct{}
-	portForwardLocalPort int // Local port for port forwarding (e.g., 8081)
+	portForwardLocalPort int  // Local port for port forwarding (e.g., 8081)
+	serviceResolved      bool // apiServerURL points at the Service; no port-forward needed
 }
 
 // NewOperations creates the appropriate Operations implementation based on the renderMode.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -22,11 +22,13 @@ type Client struct {
 	cachedDiscoveryClient *disk.CachedDiscoveryClient
 	mapper                *restmapper.DeferredDiscoveryRESTMapper
 	config                *rest.Config
+	inCluster             bool
 }
 
 func NewClient(disableClientThrottling bool) (*Client, error) {
 
 	var config *rest.Config
+	inCluster := false
 
 	// try to use kubeconfig
 	kubeConfigPath, exists := GetKubeConfigPath()
@@ -50,6 +52,7 @@ func NewClient(disableClientThrottling bool) (*Client, error) {
 			log.Debug().Err(err).Msg("Failed to create k8s client from service account")
 		} else {
 			config = c
+			inCluster = true
 			log.Info().Msg("📡 Using service account and environment variables to connect to cluster")
 		}
 	}
@@ -96,12 +99,23 @@ func NewClient(disableClientThrottling bool) (*Client, error) {
 		cachedDiscoveryClient: cachedDiscoveryClient,
 		mapper:                mapper,
 		config:                config,
+		inCluster:             inCluster,
 	}, nil
 }
 
 // GetConfig returns the rest.Config used by the client
 func (c *Client) GetConfig() *rest.Config {
 	return c.config
+}
+
+// IsInCluster reports whether the client was configured from an in-cluster
+// service account instead of an external kubeconfig.
+func (c *Client) IsInCluster() bool {
+	if c == nil {
+		return false
+	}
+
+	return c.inCluster
 }
 
 // GetKubeConfigPath returns the path to the kubeconfig file and a boolean indicating if the file exists

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
@@ -90,28 +91,92 @@ func (c *Client) PortForwardToPod(namespace, podName string, localPort, remotePo
 // GetServiceNameByLabel finds a service in the namespace with the specified label selector
 // Returns the name of the first matching service, or an error if no service is found
 func (c *Client) GetServiceNameByLabel(namespace, labelSelector string) (string, error) {
-	// Create a Kubernetes clientset
-	clientset, err := kubernetes.NewForConfig(c.config)
+	service, err := c.GetServiceByLabel(namespace, labelSelector)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kubernetes clientset: %w", err)
+		return "", err
 	}
 
-	// List services matching the label selector
+	serviceName := service.Name
+	log.Debug().Msgf("Found service %s with label %s in namespace %s", serviceName, labelSelector, namespace)
+	return serviceName, nil
+}
+
+// GetServiceByLabel finds a service in the namespace with the specified label selector.
+// If multiple services match, it returns the lexicographically first service name so
+// address discovery is deterministic.
+func (c *Client) GetServiceByLabel(namespace, labelSelector string) (*corev1.Service, error) {
+	clientset, err := kubernetes.NewForConfig(c.config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
 	services, err := clientset.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to list services with label %s: %w", labelSelector, err)
+		return nil, fmt.Errorf("failed to list services with label %s: %w", labelSelector, err)
 	}
 
 	if len(services.Items) == 0 {
-		return "", fmt.Errorf("no services found with label %s in namespace %s", labelSelector, namespace)
+		return nil, fmt.Errorf("no services found with label %s in namespace %s", labelSelector, namespace)
 	}
 
-	// Return the first matching service name
-	serviceName := services.Items[0].Name
-	log.Debug().Msgf("Found service %s with label %s in namespace %s", serviceName, labelSelector, namespace)
-	return serviceName, nil
+	sort.Slice(services.Items, func(i, j int) bool {
+		return services.Items[i].Name < services.Items[j].Name
+	})
+
+	return &services.Items[0], nil
+}
+
+// GetServiceAddressByLabel builds an in-cluster DNS address for a service
+// selected by label, using the preferred named port when available, then the
+// preferred numeric port, then the first service port.
+func (c *Client) GetServiceAddressByLabel(namespace, labelSelector, preferredPortName string, preferredPort int32) (string, error) {
+	service, err := c.GetServiceByLabel(namespace, labelSelector)
+	if err != nil {
+		return "", err
+	}
+
+	port, err := chooseServicePort(service, preferredPortName, preferredPort)
+	if err != nil {
+		return "", err
+	}
+
+	address := serviceDNSAddress(service.Name, namespace, port)
+	log.Debug().Msgf("Found service address %s with label %s in namespace %s", address, labelSelector, namespace)
+	return address, nil
+}
+
+func chooseServicePort(service *corev1.Service, preferredPortName string, preferredPort int32) (int32, error) {
+	if service == nil {
+		return 0, fmt.Errorf("service is nil")
+	}
+
+	if len(service.Spec.Ports) == 0 {
+		return 0, fmt.Errorf("service %s has no ports", service.Name)
+	}
+
+	if preferredPortName != "" {
+		for _, port := range service.Spec.Ports {
+			if port.Name == preferredPortName {
+				return port.Port, nil
+			}
+		}
+	}
+
+	if preferredPort > 0 {
+		for _, port := range service.Spec.Ports {
+			if port.Port == preferredPort {
+				return port.Port, nil
+			}
+		}
+	}
+
+	return service.Spec.Ports[0].Port, nil
+}
+
+func serviceDNSAddress(serviceName, namespace string, port int32) string {
+	return fmt.Sprintf("%s.%s.svc:%d", serviceName, namespace, port)
 }
 
 // PortForwardToService sets up a port forward to a service by finding a pod for that service

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 )
 
@@ -41,5 +43,65 @@ func TestFallbackCondition(t *testing.T) {
 					tt.shouldFallback, result, tt.err)
 			}
 		})
+	}
+}
+
+func TestChooseServicePort(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "argocd-repo-server"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "metrics", Port: 8084},
+				{Name: "server", Port: 8081},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		preferredPortName string
+		preferredPort     int32
+		want              int32
+	}{
+		{
+			name:              "prefers named port",
+			preferredPortName: "server",
+			preferredPort:     8084,
+			want:              8081,
+		},
+		{
+			name:              "falls back to preferred numeric port",
+			preferredPortName: "grpc",
+			preferredPort:     8081,
+			want:              8081,
+		},
+		{
+			name:              "falls back to first port",
+			preferredPortName: "grpc",
+			preferredPort:     9090,
+			want:              8084,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := chooseServicePort(service, tt.preferredPortName, tt.preferredPort)
+			if err != nil {
+				t.Fatalf("chooseServicePort() error = %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("chooseServicePort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceDNSAddress(t *testing.T) {
+	got := serviceDNSAddress("argocd-repo-server", "argocd", 8081)
+	want := "argocd-repo-server.argocd.svc:8081"
+
+	if got != want {
+		t.Fatalf("serviceDNSAddress() = %q, want %q", got, want)
 	}
 }

--- a/pkg/reposerver/client.go
+++ b/pkg/reposerver/client.go
@@ -38,6 +38,9 @@ const (
 	maxGenerateRetries = 5
 	// generateRetryBaseDelay is the initial backoff delay before the first retry.
 	generateRetryBaseDelay = 500 * time.Millisecond
+
+	repoServerLabelSelector   = "app.kubernetes.io/part-of=argocd,app.kubernetes.io/component=repo-server"
+	repoServerServicePortName = "server"
 )
 
 // Client is a gRPC client for the Argo CD repo server.
@@ -85,6 +88,24 @@ func NewClientWithAddress(address string, disableTLS bool, insecureSkipVerify bo
 	}
 }
 
+// EnsureConnection makes the repo server reachable. In-cluster runs use the
+// repo-server Service DNS name directly so Kubernetes can load-balance between
+// pods. External runs keep the existing port-forward behavior.
+func (c *Client) EnsureConnection() error {
+	if c.k8sClient != nil && c.k8sClient.IsInCluster() {
+		address, err := c.k8sClient.GetServiceAddressByLabel(c.namespace, repoServerLabelSelector, repoServerServicePortName, repoServerRemotePort)
+		if err != nil {
+			return fmt.Errorf("failed to find Argo CD repo server service address (label: %s): %w", repoServerLabelSelector, err)
+		}
+
+		c.address = address
+		log.Debug().Str("address", address).Msg("Using Argo CD repo server service address")
+		return nil
+	}
+
+	return c.EnsurePortForward()
+}
+
 // EnsurePortForward starts a port-forward to the Argo CD repo server if one is
 // not already running. It is idempotent and safe to call concurrently.
 func (c *Client) EnsurePortForward() error {
@@ -105,11 +126,10 @@ func (c *Client) EnsurePortForward() error {
 	readyChan := make(chan struct{}, 1)
 	stopChan := make(chan struct{}, 1)
 
-	labelSelector := "app.kubernetes.io/part-of=argocd,app.kubernetes.io/component=repo-server"
-	serviceName, err := c.k8sClient.GetServiceNameByLabel(c.namespace, labelSelector)
+	serviceName, err := c.k8sClient.GetServiceNameByLabel(c.namespace, repoServerLabelSelector)
 	if err != nil {
 		c.portForwardMutex.Unlock()
-		return fmt.Errorf("failed to find Argo CD repo server service (label: %s): %w", labelSelector, err)
+		return fmt.Errorf("failed to find Argo CD repo server service (label: %s): %w", repoServerLabelSelector, err)
 	}
 
 	log.Debug().Msgf("Starting port forward from localhost:%d to %s:%d in namespace %s",

--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -186,12 +186,12 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 	}
 
 	// Create a single repo server client shared across all goroutines.
-	// EnsurePortForward is idempotent and mutex-protected inside the client.
+	// EnsureConnection uses direct Service DNS in cluster and port-forwarding outside the cluster.
 	repoClient := reposerver.NewClient(argocd.K8sClient, argocd.Namespace)
 	defer repoClient.Cleanup()
 
-	if err := repoClient.EnsurePortForward(); err != nil {
-		return nil, nil, time.Since(startTime), fmt.Errorf("failed to set up port forward to repo server: %w", err)
+	if err := repoClient.EnsureConnection(); err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to connect to repo server: %w", err)
 	}
 
 	log.Info().Msgf("🤖 Rendering Applications via repo server with app-of-apps traversal (timeout in %d seconds)", timeout)

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -117,12 +117,12 @@ func RenderApplicationsFromBothBranches(
 	}
 
 	// Create a single repo server client shared across all goroutines.
-	// EnsurePortForward is idempotent and mutex-protected inside the client.
+	// EnsureConnection uses direct Service DNS in cluster and port-forwarding outside the cluster.
 	repoClient := reposerver.NewClient(argocd.K8sClient, argocd.Namespace)
 	defer repoClient.Cleanup()
 
-	if err := repoClient.EnsurePortForward(); err != nil {
-		return nil, nil, time.Since(startTime), fmt.Errorf("failed to set up port forward to repo server: %w", err)
+	if err := repoClient.EnsureConnection(); err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to connect to repo server: %w", err)
 	}
 
 	allApps := append(baseApps, targetApps...)


### PR DESCRIPTION
Adds `--repo-server-address` for `--render-method=repo-server-api`: when set, the tool dials the repo server at that `host:port` (e.g. `argocd-repo-server.argocd.svc:8081`) via the existing-but-unwired `NewClientWithAddress`, and skips `EnsurePortForward`. Empty (default) = unchanged port-forward behavior, so it's backward compatible.

Motivation: running the tool in-cluster and connecting to the repo-server Service directly (kube-proxy load-balanced, survives pod churn) instead of a single-pod port-forward.