### PR TITLE
Feat | Timeout repo credential fetch

### DIFF
--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -180,7 +180,7 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 	// The repo server has no access to Kubernetes secrets - credentials must be
 	// provided by the caller in every ManifestRequest. We mirror what the
 	// ArgoCD app controller does in controller/state.go before calling the repo server.
-	creds, err := FetchRepoCreds(context.Background(), argocd.K8sClient, argocd.Namespace, appRepoURLs)
+	creds, err := FetchRepoCredsWithTimeout(context.Background(), repoCredsFetchTimeout, argocd.K8sClient, argocd.Namespace, appRepoURLs)
 	if err != nil {
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to fetch repository credentials: %w", err)
 	}

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -111,7 +111,7 @@ func RenderApplicationsFromBothBranches(
 	// The repo server has no access to Kubernetes secrets - credentials must be
 	// provided by the caller in every ManifestRequest. We mirror what the
 	// ArgoCD app controller does in controller/state.go before calling the repo server.
-	creds, err := FetchRepoCreds(context.Background(), argocd.K8sClient, argocd.Namespace, appRepoURLs)
+	creds, err := FetchRepoCredsWithTimeout(context.Background(), repoCredsFetchTimeout, argocd.K8sClient, argocd.Namespace, appRepoURLs)
 	if err != nil {
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to fetch repository credentials: %w", err)
 	}

--- a/pkg/reposerverextract/repocreds.go
+++ b/pkg/reposerverextract/repocreds.go
@@ -32,7 +32,7 @@ import (
 	"github.com/dag-andersen/argocd-diff-preview/pkg/k8s"
 )
 
-const repoCredsFetchTimeout = 10 * time.Second
+const repoCredsFetchTimeout = 30 * time.Second
 
 // RepoCreds is a pre-fetched snapshot of all repository credentials registered
 // in the ArgoCD installation. It is built once and shared across all concurrent

--- a/pkg/reposerverextract/repocreds.go
+++ b/pkg/reposerverextract/repocreds.go
@@ -17,8 +17,10 @@ package reposerverextract
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/db"
@@ -29,6 +31,8 @@ import (
 
 	"github.com/dag-andersen/argocd-diff-preview/pkg/k8s"
 )
+
+const repoCredsFetchTimeout = 10 * time.Second
 
 // RepoCreds is a pre-fetched snapshot of all repository credentials registered
 // in the ArgoCD installation. It is built once and shared across all concurrent
@@ -53,6 +57,30 @@ type RepoCreds struct {
 	// reposByURL is a map from normalised repository URL → fully-enriched
 	// Repository struct (with credentials). Used to populate ManifestRequest.Repo.
 	reposByURL map[string]*v1alpha1.Repository
+}
+
+// FetchRepoCredsWithTimeout fetches repository credentials with a hard timeout.
+//
+// This fail-fast wrapper prevents CI from appearing stuck when Argo CD settings
+// informer sync or repository credential lookups block, usually because RBAC is
+// missing for configmaps or secrets in the Argo CD namespace.
+func FetchRepoCredsWithTimeout(ctx context.Context, timeout time.Duration, k8sClient *k8s.Client, namespace string, appRepoURLs []string) (*RepoCreds, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	creds, err := FetchRepoCreds(fetchCtx, k8sClient, namespace, appRepoURLs)
+	if err != nil {
+		if errors.Is(fetchCtx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("timed out after %s fetching Argo CD repository credentials: %w", timeout, err)
+		}
+		return nil, err
+	}
+
+	if errors.Is(fetchCtx.Err(), context.DeadlineExceeded) {
+		return nil, fmt.Errorf("timed out after %s fetching Argo CD repository credentials", timeout)
+	}
+
+	return creds, nil
 }
 
 // FetchRepoCreds connects to the cluster via the ArgoCD DB layer and fetches


### PR DESCRIPTION
## Summary
- Add a 30 second timeout around repo credential fetching in repo-server render mode
- Use the timeout in both normal and app-of-apps repo-server render paths
- Fail fast instead of letting CI appear stuck when Argo CD settings informers or credential lookups block

## Testing
- go test ./pkg/reposerverextract