### PR TITLE
Fix | Fallback for missing repo server local sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Chore | Update ArgoCD dependency to v3.0
 
 - A repository can contain multiple applications and applications with the same name. We ALWAYS need to make sure the names are unique.
 - We can not make any assumption of how the code i structured and how many applications are stored in the same file.
+- Design and test with realistic scale in mind. A repository can contain around 2000 Argo CD Applications. A large run may need to process around 500 Applications, but with good watch patterns and selectors we usually expect to process around 20 Applications per run.
 
 
 ## Key Dependencies

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -607,6 +607,15 @@ func buildManifestRequestForSource(
 		}
 		streamDir, cleanup, err := buildStreamDirForLocalSource(branchFolder, primarySource)
 		if err != nil {
+			if isLocalSourceMissing(err) {
+				log.Warn().
+					Str("App", app.GetLongName()).
+					Str("sourceRepoURL", primarySource.RepoURL).
+					Str("sourcePath", primarySource.Path).
+					Str("branchFolder", branchFolder).
+					Msg("⚠️ PR repo source is not present in the local branch folder - using remote RPC")
+				return newManifestRequest(&primarySource), "", nil, nil
+			}
 			return nil, "", nil, err
 		}
 		requestSource := primarySource
@@ -643,6 +652,16 @@ func buildManifestRequestForSource(
 	// from its own git cache.
 	if primarySource.Chart != "" {
 		if renderContext.puller != nil && !hasExternalRefSource(refSources, renderContext.repoSelector) {
+			if available, reason := localRefSourcesAvailable(branchFolder, primarySource, refSources); !available {
+				log.Warn().
+					Str("App", app.GetLongName()).
+					Str("branchFolder", branchFolder).
+					Str("reason", reason).
+					Msg("⚠️ PR repo ref source is not present in the local branch folder - using remote RPC")
+				request = newManifestRequest(&primarySource)
+				request.RefSources = buildRefSourcesMap(refSources, creds)
+				return request, "", nil, nil
+			}
 			return buildRemoteChartLocalRefsRequest(
 				app, primarySource, refSources, branchFolder, creds, renderContext.puller, newManifestRequest)
 		}
@@ -665,6 +684,18 @@ func buildManifestRequestForSource(
 			Str("sourceRepoURL", primarySource.RepoURL).
 			Str("prRepo", renderContext.repoSelector.String()).
 			Msg("Source or ref repoURL does not match PR repo (slow path) - using remote RPC")
+		request = newManifestRequest(&primarySource)
+		request.RefSources = buildRefSourcesMap(refSources, creds)
+		return request, "", nil, nil
+	}
+
+	if available, reason := localContentAndRefSourcesAvailable(branchFolder, primarySource, refSources); !available {
+		log.Warn().
+			Str("App", app.GetLongName()).
+			Str("sourceRepoURL", primarySource.RepoURL).
+			Str("branchFolder", branchFolder).
+			Str("reason", reason).
+			Msg("⚠️ PR repo source is not present in the local branch folder - using remote RPC")
 		request = newManifestRequest(&primarySource)
 		request.RefSources = buildRefSourcesMap(refSources, creds)
 		return request, "", nil, nil

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -305,6 +305,102 @@ spec:
 	require.Len(t, req.ApplicationSource.Helm.ValueFiles, 1)
 	assert.Equal(t, "$local/clusters/prod/cert-manager-values.yaml", req.ApplicationSource.Helm.ValueFiles[0],
 		"value file path must remain as a $ref path for the remote RPC")
+	assertDefaultProjectFields(t, req)
+}
+
+func TestBuildManifestRequest_MatchingPRRepoMissingLocalPath_UsesRemoteRPC(t *testing.T) {
+	branchFolder := t.TempDir()
+	// Simulate a resource-repo pipeline where the branch folder contains the
+	// Application repository checkout, not the PR resource repository files.
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "clusters", "preview", "applicationsets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "clusters", "preview", "applicationsets", "apps.yaml"), []byte("kind: ApplicationSet\n"), 0o644))
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preview-worker
+spec:
+  destination:
+    namespace: workers
+  source:
+    repoURL: https://github.com/example/resource-config.git
+    path: environments/preview/apps/worker
+    targetRevision: HEAD
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+	require.Empty(t, refSources)
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
+		repoSelector: testRepoSelector(t, "example/resource-config"),
+	})
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	assert.Empty(t, streamDir, "missing local PR repo source path should fall back to remote RPC")
+	assert.Equal(t, "https://github.com/example/resource-config.git", req.Repo.Repo)
+	assert.Equal(t, "environments/preview/apps/worker", req.ApplicationSource.Path)
+	assert.Nil(t, req.RefSources)
+	assertDefaultProjectFields(t, req)
+}
+
+func TestBuildManifestRequest_ExternalChart_WithMissingLocalRefValueFile_UsesRemoteRPC(t *testing.T) {
+	branchFolder := t.TempDir()
+	// Simulate a resource-repo pipeline where $local points at the PR repo, but the
+	// local checkout is the Application repository and lacks resource values.
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "clusters", "preview", "applicationsets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "clusters", "preview", "applicationsets", "charts-from-list.yaml"), []byte("kind: ApplicationSet\n"), 0o644))
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preview-cache
+spec:
+  destination:
+    namespace: cache
+  sources:
+    - repoURL: https://github.com/example/resource-config.git
+      targetRevision: HEAD
+      ref: local
+    - chart: redis
+      repoURL: https://charts.example.invalid
+      targetRevision: 1.2.3
+      helm:
+        valueFiles:
+          - $local/environments/preview/charts/values/redis.yaml
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+	require.Len(t, refSources, 1)
+	puller := &fakeChartPuller{}
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
+		repoSelector: testRepoSelector(t, "example/resource-config"),
+		puller:       puller,
+	})
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	assert.Empty(t, streamDir, "missing local PR repo ref value file should fall back to remote RPC")
+	assert.Empty(t, puller.pulled, "remote fallback should not pull and stream the chart locally")
+	assert.Equal(t, "redis", req.ApplicationSource.Chart)
+	require.NotNil(t, req.ApplicationSource.Helm)
+	assert.Equal(t, []string{"$local/environments/preview/charts/values/redis.yaml"}, req.ApplicationSource.Helm.ValueFiles)
+	require.NotNil(t, req.RefSources)
+	refTarget, ok := req.RefSources["$local"]
+	require.True(t, ok)
+	assert.Equal(t, "https://github.com/example/resource-config.git", refTarget.Repo.Repo)
+	assert.Equal(t, "HEAD", refTarget.TargetRevision)
 	assertDefaultProjectFields(t, req)
 }
 

--- a/pkg/reposerverextract/local_sources.go
+++ b/pkg/reposerverextract/local_sources.go
@@ -1,0 +1,83 @@
+package reposerverextract
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func isLocalSourceMissing(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
+}
+
+func localContentAndRefSourcesAvailable(branchFolder string, primarySource v1alpha1.ApplicationSource, refSources []v1alpha1.ApplicationSource) (bool, string) {
+	if primarySource.Path != "" {
+		if ok, reason := localPathExists(filepath.Join(branchFolder, primarySource.Path), "content source"); !ok {
+			return false, reason
+		}
+	}
+	return localRefSourcesAvailable(branchFolder, primarySource, refSources)
+}
+
+func localRefSourcesAvailable(branchFolder string, primarySource v1alpha1.ApplicationSource, refSources []v1alpha1.ApplicationSource) (bool, string) {
+	if primarySource.Helm == nil {
+		for _, ref := range refSources {
+			if ok, reason := localPathExists(localRefSourceRoot(branchFolder, ref), fmt.Sprintf("ref source %q", ref.Ref)); !ok {
+				return false, reason
+			}
+		}
+		return true, ""
+	}
+
+	refsByName := make(map[string]v1alpha1.ApplicationSource, len(refSources))
+	for _, ref := range refSources {
+		refsByName[ref.Ref] = ref
+	}
+
+	checkedRefs := map[string]bool{}
+	for _, valueFile := range primarySource.Helm.ValueFiles {
+		refName, refPath, ok := splitRefPath(valueFile)
+		if !ok {
+			continue
+		}
+		ref, found := refsByName[refName]
+		if !found {
+			continue
+		}
+		checkedRefs[refName] = true
+		if ok, reason := localPathExists(filepath.Join(localRefSourceRoot(branchFolder, ref), refPath), fmt.Sprintf("ref value file %q", valueFile)); !ok {
+			return false, reason
+		}
+	}
+
+	for _, ref := range refSources {
+		if checkedRefs[ref.Ref] {
+			continue
+		}
+		if ok, reason := localPathExists(localRefSourceRoot(branchFolder, ref), fmt.Sprintf("ref source %q", ref.Ref)); !ok {
+			return false, reason
+		}
+	}
+
+	return true, ""
+}
+
+func localRefSourceRoot(branchFolder string, ref v1alpha1.ApplicationSource) string {
+	if ref.Path == "" {
+		return branchFolder
+	}
+	return filepath.Join(branchFolder, ref.Path)
+}
+
+func localPathExists(path, description string) (bool, string) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Sprintf("%s path %q does not exist", description, path)
+		}
+		return false, fmt.Sprintf("failed to inspect %s path %q: %v", description, path, err)
+	}
+	return true, ""
+}


### PR DESCRIPTION
## Summary
- fall back to remote repo-server rendering when a matching PR repo source path is not available in the local branch checkout
- fall back to remote repo-server rendering when same-repo Helm ref value files are missing locally
- add generic regression tests for resource-repo pipeline style checkouts
- document the expected Application scale for future coding agents

## Testing
- go test ./pkg/reposerverextract/...
- make run-unit-tests