### PR TITLE
Fix | Auto-detect repository selector

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dag-andersen/argocd-diff-preview/pkg/app_selector"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/cluster"
+	"github.com/dag-andersen/argocd-diff-preview/pkg/git"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/k3d"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/kind"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/minikube"
@@ -377,9 +378,6 @@ func (o *RawOptions) checkRequired() []string {
 	if o.TargetBranch == "" {
 		errors = append(errors, "target-branch")
 	}
-	if o.Repo == "" && o.RepoRegex == "" {
-		errors = append(errors, "repo or repo-regex")
-	}
 	if o.Repo != "" && o.RepoRegex != "" {
 		errors = append(errors, "repo and repo-regex are mutually exclusive")
 	}
@@ -453,7 +451,9 @@ func (o *RawOptions) ToConfig() (*Config, error) {
 		return nil, fmt.Errorf("invalid file-regex: %w", err)
 	}
 
-	cfg.RepoSelector, err = o.parseRepositorySelector()
+	// Resolve the repository selector, auto-detecting from the checkout
+	// folders when neither --repo nor --repo-regex is provided.
+	cfg.RepoSelector, err = o.parseRepositorySelector(cfg.BaseBranch, cfg.TargetBranch)
 	if err != nil {
 		return nil, err
 	}
@@ -532,12 +532,39 @@ func (o *RawOptions) parseFileRegex() (*regexp.Regexp, error) {
 	return regexp.Compile(o.FileRegex)
 }
 
-// parseRepositorySelector returns a Repository Selector based on the repo or repo-regex flags
-func (o *RawOptions) parseRepositorySelector() (repository.Selector, error) {
+// parseRepositorySelector returns a Repository Selector based on the repo or
+// repo-regex flags. When neither is set, it auto-detects the repository from
+// the base and target checkout folders (both must share the same origin
+// remote).
+func (o *RawOptions) parseRepositorySelector(baseBranch, targetBranch string) (repository.Selector, error) {
+	if o.Repo == "" && o.RepoRegex == "" {
+		return autoDetectRepositorySelector(baseBranch, targetBranch)
+	}
+
 	repoSelector, err := repository.NewSelector(o.Repo, o.RepoRegex)
 	if err != nil {
 		return repository.Selector{}, fmt.Errorf("invalid repo-regex: %w", err)
 	}
+	return *repoSelector, nil
+}
+
+// autoDetectRepositorySelector returns the owner/repo detected from the origin
+// remote shared by the base and target checkout folders.
+func autoDetectRepositorySelector(baseBranch, targetBranch string) (repository.Selector, error) {
+	baseFolder := git.NewBranch(baseBranch, git.Base).FolderName()
+	targetFolder := git.NewBranch(targetBranch, git.Target).FolderName()
+
+	repo, ok := repository.DetectMatchingOriginRepo(baseFolder, targetFolder)
+	if !ok {
+		return repository.Selector{}, fmt.Errorf("could not auto-detect repository. please provide --repo or --repo-regex")
+	}
+
+	repoSelector, err := repository.NewSelector(repo, "")
+	if err != nil {
+		return repository.Selector{}, fmt.Errorf("invalid auto-detected repository: %w", err)
+	}
+	repoSelector.IsAutoDetected = true
+
 	return *repoSelector, nil
 }
 
@@ -681,7 +708,11 @@ func (o *Config) LogConfig() {
 		log.Info().Msgf("✨ - argocd-config-dir: %s", o.ArgocdConfigPath)
 	}
 	if o.RepoSelector.Repo != "" {
-		log.Info().Msgf("✨ - repo: %s", o.RepoSelector.Repo)
+		if o.RepoSelector.IsAutoDetected {
+			log.Info().Msgf("✨ - repo: %s (auto-detected)", o.RepoSelector.Repo)
+		} else {
+			log.Info().Msgf("✨ - repo: %s", o.RepoSelector.Repo)
+		}
 	}
 	if o.RepoSelector.Regex != nil {
 		log.Info().Msgf("✨ - repo-regex: %s", o.RepoSelector.Regex.String())

--- a/pkg/repository/autodetect.go
+++ b/pkg/repository/autodetect.go
@@ -1,0 +1,173 @@
+package repository
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DetectMatchingOriginRepo reads Git metadata from two checkout folders and
+// returns owner/repo when both checkouts have the same origin remote.
+func DetectMatchingOriginRepo(baseFolder, targetFolder string) (string, bool) {
+	baseRepo, err := repoFromGitFolder(baseFolder)
+	if err != nil {
+		return "", false
+	}
+
+	targetRepo, err := repoFromGitFolder(targetFolder)
+	if err != nil {
+		return "", false
+	}
+
+	if baseRepo == "" || targetRepo == "" || baseRepo != targetRepo {
+		return "", false
+	}
+
+	return baseRepo, true
+}
+
+func repoFromGitFolder(folder string) (string, error) {
+	gitDir, err := resolveGitDir(folder)
+	if err != nil {
+		return "", err
+	}
+
+	remoteURL, err := originRemoteURL(gitDir)
+	if err != nil {
+		return "", err
+	}
+
+	repo, ok := repoPathFromRemoteURL(remoteURL)
+	if !ok {
+		return "", fmt.Errorf("could not parse repository from remote URL")
+	}
+
+	return repo, nil
+}
+
+func resolveGitDir(folder string) (string, error) {
+	gitPath := filepath.Join(folder, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+
+	if info.IsDir() {
+		return gitPath, nil
+	}
+
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(content)), "gitdir:")
+	if !ok {
+		return "", fmt.Errorf("unsupported .git file format")
+	}
+
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(folder, gitDir)
+	}
+
+	return filepath.Clean(gitDir), nil
+}
+
+func originRemoteURL(gitDir string) (string, error) {
+	for _, configPath := range gitConfigPaths(gitDir) {
+		remoteURL, err := originRemoteURLFromConfig(configPath)
+		if err == nil && remoteURL != "" {
+			return remoteURL, nil
+		}
+	}
+
+	return "", fmt.Errorf("origin remote URL not found")
+}
+
+func gitConfigPaths(gitDir string) []string {
+	paths := []string{filepath.Join(gitDir, "config")}
+
+	commonDirPath := filepath.Join(gitDir, "commondir")
+	content, err := os.ReadFile(commonDirPath)
+	if err != nil {
+		return paths
+	}
+
+	commonDir := strings.TrimSpace(string(content))
+	if commonDir == "" {
+		return paths
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(gitDir, commonDir)
+	}
+
+	paths = append(paths, filepath.Join(filepath.Clean(commonDir), "config"))
+	return paths
+}
+
+func originRemoteURLFromConfig(configPath string) (string, error) {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", err
+	}
+
+	inOriginRemote := false
+	for line := range strings.SplitSeq(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inOriginRemote = line == `[remote "origin"]`
+			continue
+		}
+		if !inOriginRemote {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "url" {
+			continue
+		}
+		return strings.TrimSpace(value), nil
+	}
+
+	return "", fmt.Errorf("origin remote URL not found in config")
+}
+
+func repoPathFromRemoteURL(remoteURL string) (string, bool) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", false
+	}
+
+	if parsed, err := url.Parse(remoteURL); err == nil && parsed.Scheme != "" {
+		return repoPathFromPath(parsed.Path)
+	}
+
+	if before, after, ok := strings.Cut(remoteURL, ":"); ok && strings.Contains(before, "@") {
+		return repoPathFromPath(after)
+	}
+
+	return repoPathFromPath(remoteURL)
+}
+
+func repoPathFromPath(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	path = strings.Trim(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+
+	owner := parts[len(parts)-2]
+	repo := parts[len(parts)-1]
+	if owner == "" || repo == "" {
+		return "", false
+	}
+
+	return owner + "/" + repo, true
+}

--- a/pkg/repository/autodetect_test.go
+++ b/pkg/repository/autodetect_test.go
@@ -1,0 +1,67 @@
+package repository
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectMatchingOriginRepo(t *testing.T) {
+	dir := t.TempDir()
+	baseFolder := filepath.Join(dir, "base-branch")
+	targetFolder := filepath.Join(dir, "target-branch")
+	writeGitConfig(t, baseFolder, "https://github.com/example/resource-config.git")
+	writeGitConfig(t, targetFolder, "git@github.com:example/resource-config.git")
+
+	repo, ok := DetectMatchingOriginRepo(baseFolder, targetFolder)
+
+	require.True(t, ok)
+	assert.Equal(t, "example/resource-config", repo)
+}
+
+func TestDetectMatchingOriginRepoReturnsFalseWhenFoldersDiffer(t *testing.T) {
+	dir := t.TempDir()
+	baseFolder := filepath.Join(dir, "base-branch")
+	targetFolder := filepath.Join(dir, "target-branch")
+	writeGitConfig(t, baseFolder, "https://github.com/example/resource-config.git")
+	writeGitConfig(t, targetFolder, "https://github.com/example/application-config.git")
+
+	repo, ok := DetectMatchingOriginRepo(baseFolder, targetFolder)
+
+	assert.False(t, ok)
+	assert.Empty(t, repo)
+}
+
+func TestRepoPathFromRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		expected  string
+	}{
+		{name: "https", remoteURL: "https://github.com/example/resource-config.git", expected: "example/resource-config"},
+		{name: "ssh URL", remoteURL: "ssh://git@github.com/example/resource-config.git", expected: "example/resource-config"},
+		{name: "scp style ssh", remoteURL: "git@github.com:example/resource-config.git", expected: "example/resource-config"},
+		{name: "without git suffix", remoteURL: "https://github.com/example/resource-config", expected: "example/resource-config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, ok := repoPathFromRemoteURL(tt.remoteURL)
+
+			require.True(t, ok)
+			assert.Equal(t, tt.expected, repo)
+		})
+	}
+}
+
+func writeGitConfig(t *testing.T, folder, remoteURL string) {
+	t.Helper()
+	gitDir := filepath.Join(folder, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte(`[remote "origin"]
+	url = `+remoteURL+`
+`), 0o644))
+}

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -8,6 +8,9 @@ import (
 type Selector struct {
 	Repo  string
 	Regex *regexp.Regexp
+	// IsAutoDetected reports whether Repo was inferred from the checkout's origin
+	// remote rather than provided explicitly via --repo / --repo-regex.
+	IsAutoDetected bool
 }
 
 func NewSelector(repo, regex string) (*Selector, error) {

--- a/pkg/repository/match_test.go
+++ b/pkg/repository/match_test.go
@@ -138,3 +138,9 @@ func TestNewSelectorInvalidRegex(t *testing.T) {
 	_, err := NewSelector("org/repo", "[")
 	assert.Error(t, err)
 }
+
+func TestNewSelectorNotAutoDetectedByDefault(t *testing.T) {
+	selector, err := NewSelector("org/repo", "")
+	assert.NoError(t, err)
+	assert.False(t, selector.IsAutoDetected, "explicitly provided selectors must not be marked auto-detected")
+}


### PR DESCRIPTION
## Summary
- Auto-detect the repository selector from matching base and target checkout origins when `--repo` / `--repo-regex` are omitted
- Remove the early required validation for `repo or repo-regex` so auto-detection can run
- Track whether a repository selector was auto-detected and show that in config logging
- Keep repository origin parsing in `pkg/repository`

## Testing
- `make go-build`
- `go test ./pkg/git/... ./pkg/repository/... ./cmd/...`
- `golangci-lint run ./cmd/... ./pkg/git/... ./pkg/repository/...`