### PR TITLE
Fix | Resolve in-cluster test lint findings

### DIFF
--- a/integration-test/in_cluster_test.go
+++ b/integration-test/in_cluster_test.go
@@ -74,7 +74,6 @@ func TestInClusterRepoServerAPI(t *testing.T) {
 	}
 
 	for _, renderMethod := range inClusterRenderMethods {
-		renderMethod := renderMethod
 		t.Run(renderMethod, func(t *testing.T) {
 			runInClusterRenderMethod(t, tc, renderMethod, outputDir)
 		})
@@ -335,7 +334,7 @@ func yamlStringList(values []string, indent int) string {
 	for _, value := range values {
 		b.WriteString(padding)
 		b.WriteString("- ")
-		b.WriteString(fmt.Sprintf("%q", value))
+		fmt.Fprintf(&b, "%q", value)
 		b.WriteString("\n")
 	}
 	return b.String()


### PR DESCRIPTION
## Summary
- Remove the unnecessary render method loop variable copy flagged by modernize.
- Replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(...)` for staticcheck QF1012.

## Testing
- golangci-lint run