### PR TITLE
Perf | Compress each source directory once, not once per Application

### DIFF
--- a/pkg/reposerver/client.go
+++ b/pkg/reposerver/client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	repoapiclient "github.com/argoproj/argo-cd/v3/reposerver/apiclient"
-	"github.com/argoproj/argo-cd/v3/util/tgzstream"
 	"github.com/dag-andersen/argocd-diff-preview/pkg/k8s"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -144,6 +143,8 @@ func (c *Client) EnsurePortForward() error {
 
 // Cleanup stops the port-forward if one was started by this client.
 func (c *Client) Cleanup() {
+	CleanupTgzCache()
+
 	c.portForwardMutex.Lock()
 	defer c.portForwardMutex.Unlock()
 
@@ -201,14 +202,19 @@ func (c *Client) GenerateManifests(ctx context.Context, appDir string, request *
 	log.Debug().
 		Str("app", request.AppName).
 		Str("dir", appDir).
-		Msg("Compressing application directory for repo server")
+		Msg("Opening application directory archive for repo server")
 
-	tgzFile, filesWritten, checksum, err := tgzstream.CompressFiles(appDir, []string{"*"}, []string{".git"})
+	// Cached per directory: Applications routinely share a source path (one chart
+	// per cluster), so compressing per Application repeats identical work. Closed,
+	// not deleted — the archive is reused by the other Applications on this path.
+	tgzFile, checksum, filesWritten, err := openCachedTgz(appDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compress app directory %q: %w", appDir, err)
 	}
 	defer func() {
-		tgzstream.CloseAndDelete(tgzFile)
+		if err := tgzFile.Close(); err != nil {
+			log.Debug().Err(err).Str("app", request.AppName).Msg("Failed to close archive handle")
+		}
 	}()
 
 	log.Debug().

--- a/pkg/reposerver/tgzcache.go
+++ b/pkg/reposerver/tgzcache.go
@@ -1,0 +1,96 @@
+package reposerver
+
+import (
+	"os"
+	"sync"
+
+	"github.com/argoproj/argo-cd/v3/util/tgzstream"
+	"github.com/rs/zerolog/log"
+)
+
+// Applications routinely share a source directory: one chart rendered per cluster
+// is one Application each, all pointing at the same path. Compressing it per
+// Application is pure waste — the archive and its checksum are identical, and the
+// repo server's manifest cache keys on that checksum, so the repeats do not even
+// produce different work on the far side.
+//
+// Measured on a 335-Application installation: 500 source entries resolve to 79
+// distinct paths, i.e. every directory is compressed 6.3 times on average. The
+// worst offender is compressed 120 times. A diff run doubles that again, since the
+// base and target branches are rendered separately.
+//
+// So compress once per directory and hand out read-only handles to the result.
+type tgzEntry struct {
+	once     sync.Once
+	path     string
+	checksum string
+	files    int
+	err      error
+}
+
+var (
+	tgzCacheMu sync.Mutex
+	tgzCache   = map[string]*tgzEntry{}
+)
+
+// compressCached compresses appDir once and returns the archive's path, its
+// checksum and the number of files written. Concurrent callers for the same
+// directory block on the first one rather than each compressing their own copy.
+//
+// The caller must open its own handle: the archive is read to EOF per request and
+// seeked back on retry, so a shared *os.File would race across goroutines.
+func compressCached(appDir string) (string, string, int, error) {
+	tgzCacheMu.Lock()
+	entry, ok := tgzCache[appDir]
+	if !ok {
+		entry = &tgzEntry{}
+		tgzCache[appDir] = entry
+	}
+	tgzCacheMu.Unlock()
+
+	entry.once.Do(func() {
+		file, files, checksum, err := tgzstream.CompressFiles(appDir, []string{"*"}, []string{".git"})
+		if err != nil {
+			entry.err = err
+			return
+		}
+		// Keep the archive on disk — CloseAndDelete would defeat the cache.
+		entry.path, entry.checksum, entry.files = file.Name(), checksum, files
+		if err := file.Close(); err != nil {
+			log.Debug().Err(err).Str("dir", appDir).Msg("Failed to close freshly compressed archive")
+		}
+	})
+
+	return entry.path, entry.checksum, entry.files, entry.err
+}
+
+// openCachedTgz returns a fresh read handle on the archive for appDir, compressing
+// it first if this is the first caller.
+func openCachedTgz(appDir string) (*os.File, string, int, error) {
+	path, checksum, files, err := compressCached(appDir)
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return file, checksum, files, nil
+}
+
+// CleanupTgzCache removes every cached archive. Safe to call more than once.
+func CleanupTgzCache() {
+	tgzCacheMu.Lock()
+	defer tgzCacheMu.Unlock()
+
+	for dir, entry := range tgzCache {
+		if entry.path == "" {
+			continue
+		}
+		if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+			log.Debug().Err(err).Str("dir", dir).Msg("Failed to remove cached archive")
+		}
+	}
+	tgzCache = map[string]*tgzEntry{}
+}


### PR DESCRIPTION
`GenerateManifests` calls `tgzstream.CompressFiles(appDir, …)` per Application. But Applications routinely share a source path — one chart rendered per cluster is one Application each, all pointing at the same directory — so the same archive, same bytes, same checksum, is produced over and over.

Measured on a 335-Application installation:

```
335 Applications → 500 source entries → 79 distinct paths
= 6.3x redundant compression on average

120x  charts/xyz
 41x  charts/abc
 29x  charts/deg
```

A diff run doubles that again, since base and target are rendered separately.

It is waste on both ends: the repo server's manifest cache keys on the checksum, so the repeats do not even produce different work there. On an in-cluster render against a warm cache the client-side compression is what dominates — measured on our render Argo mid-render:


## Change

Cache per directory, keyed on `appDir`, with a `sync.Once` so concurrent callers block on the first rather than each compressing their own copy.

Each request still opens its own handle. The archive is read to EOF and seeked back on retry, so a shared `*os.File` would race across goroutines — `os.Open` on the cached path is cheap by comparison.

`CloseAndDelete` is replaced by a plain `Close`, since deleting would defeat the cache; `Client.Cleanup()` removes the archives at the end instead.

No API change, no new flag, no new dependency.