### PR TITLE
Fix | Do not fall back to the remote RPC for optional value files

### DIFF
--- a/pkg/reposerverextract/local_sources.go
+++ b/pkg/reposerverextract/local_sources.go
@@ -49,6 +49,15 @@ func localRefSourcesAvailable(branchFolder string, primarySource v1alpha1.Applic
 		}
 		checkedRefs[refName] = true
 		if ok, reason := localPathExists(filepath.Join(localRefSourceRoot(branchFolder, ref), refPath), fmt.Sprintf("ref value file %q", valueFile)); !ok {
+			// With ignoreMissingValueFiles the file is optional by declaration, and
+			// Argo CD skips it when rendering. The branch folder is a full checkout
+			// of the very commit being rendered, so absent here means absent there —
+			// falling back to the remote RPC cannot produce the file, it only costs
+			// a round trip per app. Common shape: an overrides/<cluster>.yaml that
+			// exists for a few clusters and not the rest.
+			if primarySource.Helm.IgnoreMissingValueFiles {
+				continue
+			}
 			return false, reason
 		}
 	}

--- a/pkg/reposerverextract/local_sources.go
+++ b/pkg/reposerverextract/local_sources.go
@@ -48,17 +48,19 @@ func localRefSourcesAvailable(branchFolder string, primarySource v1alpha1.Applic
 			continue
 		}
 		checkedRefs[refName] = true
-		if ok, reason := localPathExists(filepath.Join(localRefSourceRoot(branchFolder, ref), refPath), fmt.Sprintf("ref value file %q", valueFile)); !ok {
-			// With ignoreMissingValueFiles the file is optional by declaration, and
-			// Argo CD skips it when rendering. The branch folder is a full checkout
-			// of the very commit being rendered, so absent here means absent there —
-			// falling back to the remote RPC cannot produce the file, it only costs
-			// a round trip per app. Common shape: an overrides/<cluster>.yaml that
-			// exists for a few clusters and not the rest.
-			if primarySource.Helm.IgnoreMissingValueFiles {
+		valueFilePath := filepath.Join(localRefSourceRoot(branchFolder, ref), refPath)
+		if _, err := os.Stat(valueFilePath); err != nil {
+			// With ignoreMissingValueFiles a nonexistent file is optional by
+			// declaration, and Argo CD skips it when rendering. The branch folder is
+			// a full checkout of the commit being rendered, so falling back to the
+			// remote RPC cannot make the file appear.
+			if primarySource.Helm.IgnoreMissingValueFiles && errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			return false, reason
+			if errors.Is(err, os.ErrNotExist) {
+				return false, fmt.Sprintf("ref value file %q path %q does not exist", valueFile, valueFilePath)
+			}
+			return false, fmt.Sprintf("failed to inspect ref value file %q path %q: %v", valueFile, valueFilePath, err)
 		}
 	}
 

--- a/pkg/reposerverextract/local_sources_test.go
+++ b/pkg/reposerverextract/local_sources_test.go
@@ -1,0 +1,77 @@
+package reposerverextract
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+)
+
+func TestLocalRefSourcesAvailableIgnoresOptionalMissingValueFile(t *testing.T) {
+	branchFolder := t.TempDir()
+	primary := v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			ValueFiles:              []string{"$values/optional.yaml"},
+			IgnoreMissingValueFiles: true,
+		},
+	}
+	refs := []v1alpha1.ApplicationSource{{Ref: "values"}}
+
+	available, reason := localRefSourcesAvailable(branchFolder, primary, refs)
+	if !available {
+		t.Fatalf("optional missing value file should keep the local render path available: %s", reason)
+	}
+}
+
+func TestLocalRefSourcesAvailableRejectsRequiredMissingValueFile(t *testing.T) {
+	branchFolder := t.TempDir()
+	primary := v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			ValueFiles: []string{"$values/required.yaml"},
+		},
+	}
+	refs := []v1alpha1.ApplicationSource{{Ref: "values"}}
+
+	available, reason := localRefSourcesAvailable(branchFolder, primary, refs)
+	if available {
+		t.Fatal("required missing value file should make the local render path unavailable")
+	}
+	if !strings.Contains(reason, "required.yaml") || !strings.Contains(reason, "does not exist") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestLocalRefSourcesAvailableRejectsMissingRefSource(t *testing.T) {
+	branchFolder := t.TempDir()
+	primary := v1alpha1.ApplicationSource{}
+	refs := []v1alpha1.ApplicationSource{{Ref: "values", Path: "missing-ref"}}
+
+	available, reason := localRefSourcesAvailable(branchFolder, primary, refs)
+	if available {
+		t.Fatal("missing ref source should make the local render path unavailable")
+	}
+	if !strings.Contains(reason, "missing-ref") || !strings.Contains(reason, "does not exist") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestLocalRefSourcesAvailableAcceptsExistingRequiredValueFile(t *testing.T) {
+	branchFolder := t.TempDir()
+	valueFile := filepath.Join(branchFolder, "required.yaml")
+	if err := os.WriteFile(valueFile, []byte("key: value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	primary := v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			ValueFiles: []string{"$values/required.yaml"},
+		},
+	}
+	refs := []v1alpha1.ApplicationSource{{Ref: "values"}}
+
+	available, reason := localRefSourcesAvailable(branchFolder, primary, refs)
+	if !available {
+		t.Fatalf("existing required value file should keep the local render path available: %s", reason)
+	}
+}


### PR DESCRIPTION
A ref value file declared optional via `ignoreMissingValueFiles` currently drops the whole Application off the local render path:

```
⚠️ PR repo ref source is not present in the local branch folder - using remote RPC
   (App: "kyverno-…poc.eu-central-1")
   (reason: ref value file "$kyverno-values/…/overrides/moia-01.k8s.poc.eu-central-1.yaml"
            path "base-branch/…/overrides/moia-01.k8s.poc.eu-central-1.yaml" does not exist")
```

`localRefSourcesAvailable` decides between two paths: stream the chart together with the locally checked-out ref directories, or use the unary `GenerateManifest` RPC and let the repo server resolve refs from git. The RPC path exists for ref sources in **other** repositories, which are not checked out.

For a ref source in the PR repo that reasoning does not apply. The branch folder is a full checkout of the exact commit being rendered, so a file absent locally is absent remotely too — the fallback cannot produce it, it only costs a round trip per Application. And with `ignoreMissingValueFiles` Argo CD skips the file when rendering anyway, so skipping it here matches what a real sync does.

The shape that triggers it is common: an `overrides/<cluster>.yaml` that exists for a few clusters and not the rest. On a 454-Application render that is hundreds of RPCs for files that exist nowhere.

Scoped to `IgnoreMissingValueFiles`. A required-but-missing file still takes the fallback, so nothing silently renders without a file it was supposed to have.