### PR TITLE
fix(repo-server-api): pass kustomize.buildOptions from argocd-cm in manifest requests

### DIFF
--- a/pkg/k8s/manifest.go
+++ b/pkg/k8s/manifest.go
@@ -229,6 +229,25 @@ func (c *Client) GetConfigMaps(namespace string, names ...string) (string, error
 	return string(resultString), nil
 }
 
+// GetConfigMapValue returns the value of a key in a ConfigMap, or "" when the key is absent.
+// e.g. key: "kustomize.buildOptions"
+func (c *Client) GetConfigMapValue(namespace string, name string, key string) (string, error) {
+	configMapRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	result, err := c.clientSet.Resource(configMapRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get ConfigMap %s: %w", name, err)
+	}
+
+	value, found, err := unstructured.NestedString(result.Object, "data", key)
+	if err != nil {
+		return "", fmt.Errorf("failed to read key %s from ConfigMap %s: %w", key, name, err)
+	}
+	if !found {
+		return "", nil
+	}
+	return value, nil
+}
+
 // get secret value from key. e.g. key: "password"
 func (c *Client) GetSecretValue(namespace string, name string, key string) (string, error) {
 	secretRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}

--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -172,6 +172,13 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
+	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
+	// the repo server never reads the ConfigMap.
+	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
+	if err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
+	}
+
 	// Collect all unique repository URLs referenced by the Applications so that
 	// FetchRepoCreds can enrich them with credentials from repo-creds templates.
 	appRepoURLs := collectRepoURLs(baseApps, targetApps)
@@ -353,7 +360,7 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(remainingTime())*time.Second)
 			defer cancel()
 
-			manifests, childApps, err := renderAppWithChildDiscovery(ctx, repoClient, argocd, item.app, branchFolderByType, branchByType, namespacedScopedResources, creds, &repoSelector, argocd.Namespace, tempFolder, item.depth, kubeVersion, apiVersions, redirectRevisions)
+			manifests, childApps, err := renderAppWithChildDiscovery(ctx, repoClient, argocd, item.app, branchFolderByType, branchByType, namespacedScopedResources, creds, &repoSelector, argocd.Namespace, tempFolder, item.depth, kubeVersion, apiVersions, kustomizeBuildOptions, redirectRevisions)
 			if err != nil {
 				results <- renderResult{err: fmt.Errorf("failed to render app %s: %w", item.app.GetLongName(), err)}
 				return
@@ -443,9 +450,10 @@ func renderAppWithChildDiscovery(
 	depth int,
 	kubeVersion string,
 	apiVersions []string,
+	kustomizeBuildOptions string,
 	redirectRevisions []string,
 ) ([]unstructured.Unstructured, []argoapplication.ArgoResource, error) {
-	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions, helmChartPuller{})
+	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions, kustomizeBuildOptions, helmChartPuller{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -103,6 +103,16 @@ func RenderApplicationsFromBothBranches(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
+	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
+	// the repo server never reads the ConfigMap.
+	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
+	if err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
+	}
+	if kustomizeBuildOptions != "" {
+		log.Info().Msgf("🔧 Using kustomize build options from argocd-cm: %s", kustomizeBuildOptions)
+	}
+
 	// Collect all unique repository URLs referenced by the Applications so that
 	// FetchRepoCreds can enrich them with credentials from repo-creds templates.
 	appRepoURLs := collectRepoURLs(baseApps, targetApps)
@@ -182,7 +192,7 @@ func RenderApplicationsFromBothBranches(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(remainingTime())*time.Second)
 			defer cancel()
 
-			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions, helmChartPuller{})
+			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions, kustomizeBuildOptions, helmChartPuller{})
 			if err != nil {
 				results <- result{err: fmt.Errorf("failed to render app %s: %w", app.GetLongName(), err)}
 				return
@@ -259,6 +269,7 @@ func renderApp(
 	repoSelector *repository.Selector,
 	kubeVersion string,
 	apiVersions []string,
+	kustomizeBuildOptions string,
 	puller chartPuller,
 ) ([]unstructured.Unstructured, error) {
 	branchFolder, ok := branchFolderByType[app.Branch]
@@ -282,10 +293,11 @@ func renderApp(
 			branchFolder,
 			creds,
 			manifestRequestRenderContext{
-				repoSelector: repoSelector,
-				kubeVersion:  kubeVersion,
-				apiVersions:  apiVersions,
-				puller:       puller,
+				repoSelector:          repoSelector,
+				kubeVersion:           kubeVersion,
+				apiVersions:           apiVersions,
+				kustomizeBuildOptions: kustomizeBuildOptions,
+				puller:                puller,
 			},
 		)
 		if err != nil {
@@ -524,6 +536,10 @@ type manifestRequestRenderContext struct {
 	repoSelector *repository.Selector
 	kubeVersion  string
 	apiVersions  []string
+	// kustomizeBuildOptions holds the global `kustomize.buildOptions` value
+	// from argocd-cm. Argo CD's API server passes it to the repo server on
+	// every request; the repo server never reads the ConfigMap itself.
+	kustomizeBuildOptions string
 	// puller fetches remote Helm charts so they can be streamed to the repo
 	// server together with same-repo $ref value files. When nil, remote charts
 	// with ref sources fall back to the unary GenerateManifest RPC.
@@ -552,7 +568,7 @@ func buildManifestRequestForSource(
 	namespace, _, _ := unstructured.NestedString(obj, append(specPath, "destination", "namespace")...)
 
 	newManifestRequest := func(source *v1alpha1.ApplicationSource) *repoapiclient.ManifestRequest {
-		return &repoapiclient.ManifestRequest{
+		request := &repoapiclient.ManifestRequest{
 			Repo:               creds.GetRepo(source.RepoURL),
 			Repos:              creds.HelmRepos(source),
 			HelmRepoCreds:      creds.HelmRepoCreds(source),
@@ -570,6 +586,12 @@ func buildManifestRequestForSource(
 			ProjectName:        "default",
 			ProjectSourceRepos: []string{"*"},
 		}
+		if renderContext.kustomizeBuildOptions != "" {
+			request.KustomizeOptions = &v1alpha1.KustomizeOptions{
+				BuildOptions: renderContext.kustomizeBuildOptions,
+			}
+		}
+		return request
 	}
 
 	// Fast path: no ref sources.

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -175,7 +175,56 @@ spec:
 	assert.Equal(t, kubeVersion, req.KubeVersion)
 	assert.Equal(t, apiVersions, req.ApiVersions)
 	assert.Nil(t, req.RefSources)
+	assert.Nil(t, req.KustomizeOptions, "no build options configured: field must stay unset")
 	assertDefaultProjectFields(t, req)
+}
+
+// Global kustomize build options from argocd-cm (e.g. --load-restrictor LoadRestrictionsNone)
+// must reach the repo server on every request, exactly like Argo CD's API server passes them;
+// the repo server never reads the ConfigMap itself.
+func TestBuildManifestRequest_KustomizeBuildOptions(t *testing.T) {
+	branchFolder := makeBranchFolder(t, "apps/my-app")
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  destination:
+    namespace: production
+  source:
+    repoURL: https://github.com/org/repo.git
+    path: apps/my-app
+    targetRevision: HEAD
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+
+	buildOptions := "--enable-alpha-plugins --enable-exec --load-restrictor LoadRestrictionsNone"
+	req, _, cleanup, err := buildManifestRequestForSource(
+		app,
+		contentSources[0],
+		refSources,
+		hasMultipleSources,
+		branchFolder,
+		nil,
+		manifestRequestRenderContext{
+			repoSelector:          testRepoSelector(t, ""),
+			kubeVersion:           "v1.30.1",
+			apiVersions:           []string{"apps/v1", "v1"},
+			kustomizeBuildOptions: buildOptions,
+		},
+	)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	require.NotNil(t, req.KustomizeOptions)
+	assert.Equal(t, buildOptions, req.KustomizeOptions.BuildOptions)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Argo CD's API server injects the global kustomize build options from `argocd-cm` into every repo-server request; the repo server never reads the ConfigMap itself. The `repo-server-api` render method built its own requests without `KustomizeOptions`, silently dropping options like `--load-restrictor LoadRestrictionsNone` — any kustomization referencing files outside its own directory failed with a load-restriction error.

Fix: read `kustomize.buildOptions` once per render run and set it on every request (both render paths). Unit-tested; validated on a ~1700-app monorepo (35 load-restriction failures → 0).