### PR TITLE
Fix | Prevent Helm logger panic

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -167,7 +167,7 @@ func (a *ArgoCDInstallation) installWithHelm() error {
 
 	// Initialize the action configuration
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(settings.RESTClientGetter(), a.Namespace, os.Getenv("HELM_DRIVER"), log.Debug().Msgf); err != nil {
+	if err := actionConfig.Init(settings.RESTClientGetter(), a.Namespace, os.Getenv("HELM_DRIVER"), helmDebugLog); err != nil {
 		return fmt.Errorf("failed to initialize helm configuration: %w", err)
 	}
 
@@ -247,6 +247,10 @@ func (a *ArgoCDInstallation) installWithHelm() error {
 
 	log.Info().Msg("🦑 Argo CD Helm chart installed successfully")
 	return nil
+}
+
+func helmDebugLog(format string, v ...any) {
+	log.Debug().Msgf(format, v...)
 }
 
 // locateHTTPChart resolves the chart path for a classic HTTP(S) Helm repo. It

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -100,6 +100,13 @@ func TestInstallWithHelm_OCIRequiresExplicitVersion(t *testing.T) {
 	}
 }
 
+func TestHelmDebugLogCanBeReused(t *testing.T) {
+	logger := helmDebugLog
+
+	logger("first helm debug message")
+	logger("second helm debug message")
+}
+
 func TestFindValuesFiles(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- Wrap the Helm debug callback so each log call creates a fresh zerolog event
- Add a regression test that reuses the Helm logger callback twice

## Testing
- golangci-lint run
- go test ./pkg/argocd
- make go-build

Fixes #471