### PR TITLE
Fix | Continue when repo-server cannot read Kustomize options

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -183,10 +183,11 @@ Each `branch-N/target[-suffix]/` directory contains expected output files (`outp
 ### Branch 15: Additional Coverage
 - `target`: Basic diff (no special options)
 
-### Branch 16-18: repo-server-api Render Method
+### Branch 16-19: repo-server-api Render Method
 - `branch-16/target`: Config Management Plugin (kustomize-build-with-helm) via `repo-server-api`
 - `branch-17/target-1` / `target-2`: App-of-apps traversal via `repo-server-api`
 - `branch-18/target`: Single-source local Helm chart whose `helm.valueFiles` reference a file OUTSIDE the chart directory via a repo-root-absolute path (`/examples/out-of-chart-values/env/values.yaml`). Regression test for `repo-server-api`: the tool must stream the whole branch folder so the out-of-chart value file is reachable, otherwise the render fails with `no such file or directory`.
+- `branch-19/target`: Kustomize resource outside the application directory via `repo-server-api`. It requires global `kustomize.buildOptions: --load-restrictor LoadRestrictionsNone` from `argocd-cm`, proving the direct repo-server request forwards that setting.
 
 ## Prerequisites
 

--- a/integration-test/branch-19/target/output.html
+++ b/integration-test/branch-19/target/output.html
@@ -1,0 +1,105 @@
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+body {
+	font-family: arial;
+}
+.container {
+	margin: auto;
+	width: 910px;
+}
+.diffs {
+	margin: 20px 0 20px 0;
+}
+.diff_container {
+	width: 910px;
+	overflow-x: scroll;
+	border-radius: 8px;
+	background:rgb(239, 239, 239);
+	scrollbar-width: none;
+	margin: 10px 0 10px 0;
+}
+table {
+	font-family: monospace;
+	border-spacing: 0px;
+	width: 100%;
+}
+tr.normal_line {
+	background:rgb(239, 239, 239);
+}
+tr.added_line {
+	background:rgb(169, 216, 184);
+}
+tr.removed_line {
+	background:rgb(247, 149, 173);
+}
+tr.comment_line {
+	background:rgb(197, 194, 194);
+}
+.resource_header {
+	font-family: monospace;
+	font-size: 14px;
+	color: rgb(80, 80, 80);
+	margin: 15px 0 5px 0;
+	padding: 0;
+}
+.resource_header:first-of-type {
+	margin-top: 10px;
+}
+pre {
+	margin: 0;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Argo CD Diff Preview</h1>
+
+<p>Summary:</p>
+<pre>Modified (1):
+± kustomize-build-options (+2|-2)</pre>
+
+<div class="diffs">
+<details>
+<summary>
+kustomize-build-options (examples/kustomize-build-options/application.yaml)
+</summary>
+
+<h4 class="resource_header">Deployment: default/kustomize-build-options</h4>
+<div class="diff_container">
+<table>
+
+	<tr class="normal_line"><td><pre> apiVersion: apps/v1</pre></td></tr>
+	<tr class="normal_line"><td><pre> kind: Deployment</pre></td></tr>
+	<tr class="normal_line"><td><pre> metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>   name: kustomize-build-options</pre></td></tr>
+	<tr class="normal_line"><td><pre>   namespace: default</pre></td></tr>
+	<tr class="normal_line"><td><pre> spec:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-  replicas: 1</pre></td></tr>
+	<tr class="added_line"><td><pre>+  replicas: 3</pre></td></tr>
+	<tr class="normal_line"><td><pre>   selector:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     matchLabels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       app: kustomize-build-options</pre></td></tr>
+	<tr class="normal_line"><td><pre>   template:</pre></td></tr>
+	<tr class="normal_line"><td><pre>     metadata:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       labels:</pre></td></tr>
+	<tr class="normal_line"><td><pre>         app: kustomize-build-options</pre></td></tr>
+	<tr class="normal_line"><td><pre>     spec:</pre></td></tr>
+	<tr class="normal_line"><td><pre>       containers:</pre></td></tr>
+	<tr class="removed_line"><td><pre>-      - image: nginx:1.25</pre></td></tr>
+	<tr class="added_line"><td><pre>+      - image: nginx:1.27</pre></td></tr>
+	<tr class="normal_line"><td><pre>         name: app</pre></td></tr>
+</table>
+</div>
+
+</details>
+</div>
+
+<pre>_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]</pre>
+</div>
+</body>
+</html>

--- a/integration-test/branch-19/target/output.md
+++ b/integration-test/branch-19/target/output.md
@@ -1,0 +1,39 @@
+## Argo CD Diff Preview
+
+Summary:
+```yaml
+Modified (1):
+± kustomize-build-options (+2|-2)
+```
+
+<details>
+<summary>kustomize-build-options (examples/kustomize-build-options/application.yaml)</summary>
+<br>
+
+#### Deployment: default/kustomize-build-options
+```diff
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: kustomize-build-options
+   namespace: default
+ spec:
+-  replicas: 1
++  replicas: 3
+   selector:
+     matchLabels:
+       app: kustomize-build-options
+   template:
+     metadata:
+       labels:
+         app: kustomize-build-options
+     spec:
+       containers:
+-      - image: nginx:1.25
++      - image: nginx:1.27
+         name: app
+```
+</details>
+
+_Stats_:
+[Applications: 2], [Full Run: Xs], [Rendering: Xs], [Cluster: Xs], [Argo CD: Xs]

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -339,6 +339,18 @@ var testCases = []TestCase{
 		FileRegex:                  "examples/out-of-chart-values/.*",
 		WatchIfNoWatchPatternFound: "false",
 	},
+	// Regression test for global Kustomize build options in repo-server-api mode.
+	// The Kustomization loads a resource outside its application directory, which
+	// requires kustomize.buildOptions=--load-restrictor LoadRestrictionsNone.
+	{
+		Name:                       "branch-19/target",
+		TargetBranch:               "integration-test/branch-19/target",
+		BaseBranch:                 "integration-test/branch-19/base",
+		RenderMethod:               "repo-server-api",
+		ArgocdConfigDir:            "kustomize-build-options",
+		FileRegex:                  "examples/kustomize-build-options/.*",
+		WatchIfNoWatchPatternFound: "false",
+	},
 	// This test verifies that disabling cluster roles without using the API fails.
 	// When createClusterRoles: false is set but --render-method=cli is used,
 	// the tool should fail because it can't access cluster resources via CLI.

--- a/integration-test/kustomize-build-options/values.yaml
+++ b/integration-test/kustomize-build-options/values.yaml
@@ -1,0 +1,6 @@
+# Repo-server API integration test: this setting must be forwarded in every
+# ManifestRequest because repo-server does not read argocd-cm itself.
+createClusterRoles: false
+configs:
+  cm:
+    kustomize.buildOptions: --load-restrictor LoadRestrictionsNone

--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -173,10 +173,12 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 	}
 
 	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
-	// the repo server never reads the ConfigMap.
+	// the repo server never reads the ConfigMap. Missing ConfigMap access must not prevent rendering,
+	// but applications that depend on global Kustomize options may then fail to render.
 	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
 	if err != nil {
-		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
+		log.Warn().Err(err).Msg("⚠️ Unable to read kustomize.buildOptions from argocd-cm. Continuing without global Kustomize options; applications that depend on them may fail to render.")
+		kustomizeBuildOptions = ""
 	}
 
 	// Collect all unique repository URLs referenced by the Applications so that

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -104,12 +104,13 @@ func RenderApplicationsFromBothBranches(
 	}
 
 	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
-	// the repo server never reads the ConfigMap.
+	// the repo server never reads the ConfigMap. Missing ConfigMap access must not prevent rendering,
+	// but applications that depend on global Kustomize options may then fail to render.
 	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
 	if err != nil {
-		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
-	}
-	if kustomizeBuildOptions != "" {
+		log.Warn().Err(err).Msg("⚠️ Unable to read kustomize.buildOptions from argocd-cm. Continuing without global Kustomize options; applications that depend on them may fail to render.")
+		kustomizeBuildOptions = ""
+	} else if kustomizeBuildOptions != "" {
 		log.Info().Msgf("🔧 Using kustomize build options from argocd-cm: %s", kustomizeBuildOptions)
 	}
 


### PR DESCRIPTION
## Summary
- Continue repo-server-api rendering when argocd-cm cannot be read, and emit a warning that global Kustomize options may be required by some applications.
- Add a repo-server-api integration regression test for kustomize.buildOptions set to --load-restrictor LoadRestrictionsNone.
- Document the new branch-19 integration case.

## Validation
- go test ./pkg/reposerverextract
- TEST_CASE="branch-19/target" go test -v -timeout 20m -run TestSingleCase ./...

The branch-19 fixture deliberately loads a resource outside the Kustomization directory. The integration test passed with the ConfigMap setting and failed with Kustomize load-restriction errors when the setting was temporarily removed.