### PR TITLE
Perf | Stage only referenced repo-server ref files

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -152,7 +152,7 @@ Each `branch-N/target[-suffix]/` directory contains expected output files (`outp
 
 ### Branch 5: Filtering Options
 - `target-1`: Filter by `--files-changed`
-- `target-2`: Filter by watch pattern in application
+- `target-2`: Filter by watch pattern in application; also verifies root `$ref` staging stays below a small repo-server archive limit
 - `target-3`: Files changed with no matching apps (empty result)
 - `target-4`: Filter by `--selector=team=my-team` with ArgoCD UI URL
 - `target-5`: Filter by selector with no matches; custom title

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -131,6 +131,9 @@ var testCases = []TestCase{
 		FilesChanged:               "examples/helm/values/filtered.yaml",
 		WatchIfNoWatchPatternFound: "false",
 	},
+	// Also covers same-repository root $ref staging. The small repo-server
+	// archive limit only passes when the referenced values file is staged instead
+	// of copying the entire repository into .refs/local-files.
 	{
 		Name:                       "branch-5/target-2",
 		TargetBranch:               "integration-test/branch-5/target",
@@ -138,6 +141,8 @@ var testCases = []TestCase{
 		Suffix:                     "-2",
 		FilesChanged:               "examples/helm/applications/watch-pattern/valid-regex.yaml",
 		WatchIfNoWatchPatternFound: "false",
+		RenderMethod:               "repo-server-api",
+		ArgocdConfigDir:            "ref-staging-size-limit",
 	},
 	{
 		Name:                       "branch-5/target-3",

--- a/integration-test/ref-staging-size-limit/values.yaml
+++ b/integration-test/ref-staging-size-limit/values.yaml
@@ -1,0 +1,7 @@
+# The existing branch-5 repository compresses to roughly 2.8 MiB because it
+# contains unrelated docs assets. This test must only stream the chart and its
+# referenced $ref values.
+createClusterRoles: false
+configs:
+  params:
+    reposerver.streamed.manifest.max.tar.size: 100Ki

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -846,13 +846,21 @@ func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.Applica
 		return refDirs, nil
 	}
 
-	refPaths := append([]string{}, primarySource.Helm.ValueFiles...)
+	type refPathToStage struct {
+		path            string
+		ignoreIfMissing bool
+	}
+	refPaths := make([]refPathToStage, 0, len(primarySource.Helm.ValueFiles)+len(primarySource.Helm.FileParameters))
+	for _, valueFile := range primarySource.Helm.ValueFiles {
+		refPaths = append(refPaths, refPathToStage{path: valueFile, ignoreIfMissing: primarySource.Helm.IgnoreMissingValueFiles})
+	}
 	for _, fileParameter := range primarySource.Helm.FileParameters {
-		refPaths = append(refPaths, fileParameter.Path)
+		refPaths = append(refPaths, refPathToStage{path: fileParameter.Path})
 	}
 	stagedFiles := map[string]struct{}{}
 	fullyStagedRefs := map[string]struct{}{}
-	for _, refValuePath := range refPaths {
+	for _, refPathToStage := range refPaths {
+		refValuePath := refPathToStage.path
 		refName, refPath, ok := splitRefPath(refValuePath)
 		if !ok {
 			if strings.HasPrefix(refValuePath, "$") {
@@ -885,7 +893,7 @@ func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.Applica
 			return nil, fmt.Errorf("invalid ref path %q for source %q: %w", refValuePath, refName, err)
 		}
 		if _, err := os.Stat(srcFile); err != nil {
-			if primarySource.Helm.IgnoreMissingValueFiles && errors.Is(err, os.ErrNotExist) {
+			if refPathToStage.ignoreIfMissing && errors.Is(err, os.ErrNotExist) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to inspect ref path %q from source %q: %w", refValuePath, refName, err)

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -850,6 +850,8 @@ func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.Applica
 	for _, fileParameter := range primarySource.Helm.FileParameters {
 		refPaths = append(refPaths, fileParameter.Path)
 	}
+	stagedFiles := map[string]struct{}{}
+	fullyStagedRefs := map[string]struct{}{}
 	for _, refValuePath := range refPaths {
 		refName, refPath, ok := splitRefPath(refValuePath)
 		if !ok {
@@ -862,8 +864,22 @@ func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.Applica
 		if !found {
 			return nil, fmt.Errorf("ref path %q references unknown ref %q", refValuePath, refName)
 		}
+		if _, staged := fullyStagedRefs[refName]; staged {
+			continue
+		}
 
 		refRoot := localRefSourceRoot(branchFolder, ref)
+		// Argo CD expands variables in ref paths during rendering. Keep the
+		// existing full-ref behavior for dynamic paths because their final file
+		// name is not known while staging.
+		if strings.Contains(refPath, "$") {
+			if err := copyDir(refRoot, refDirs[refName]); err != nil {
+				return nil, fmt.Errorf("failed to stage dynamic ref source %q: %w", refName, err)
+			}
+			fullyStagedRefs[refName] = struct{}{}
+			continue
+		}
+
 		srcFile, relPath, err := resolveRefFilePath(refRoot, refPath)
 		if err != nil {
 			return nil, fmt.Errorf("invalid ref path %q for source %q: %w", refValuePath, refName, err)
@@ -874,9 +890,14 @@ func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.Applica
 			}
 			return nil, fmt.Errorf("failed to inspect ref path %q from source %q: %w", refValuePath, refName, err)
 		}
+		stagingKey := refName + "\x00" + relPath
+		if _, staged := stagedFiles[stagingKey]; staged {
+			continue
+		}
 		if err := copyFile(srcFile, filepath.Join(refDirs[refName], relPath)); err != nil {
 			return nil, fmt.Errorf("failed to stage ref path %q from source %q: %w", refValuePath, refName, err)
 		}
+		stagedFiles[stagingKey] = struct{}{}
 	}
 	return refDirs, nil
 }

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -15,6 +15,7 @@ package reposerverextract
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -744,8 +745,9 @@ func buildManifestRequestForSource(
 		return nil, "", nil, fmt.Errorf("failed to copy content source dir %q: %w", srcContentDir, err)
 	}
 
-	// Copy each ref source into <tempDir>/.refs/<refName>/.
-	refDirs, err := stageRefSources(tempDir, branchFolder, refSources)
+	// Copy only the ref files used by this content source into
+	// <tempDir>/.refs/<refName>/.
+	refDirs, err := stageRefSources(tempDir, branchFolder, refSources, primarySource)
 	if err != nil {
 		cleanup()
 		return nil, "", nil, err
@@ -797,8 +799,8 @@ func buildRemoteChartLocalRefsRequest(
 		return nil, "", nil, fmt.Errorf("failed to pull chart for app %s: %w", app.GetLongName(), err)
 	}
 
-	// Stage the same-repo ref sources next to the chart.
-	refDirs, err := stageRefSources(tempDir, branchFolder, refSources)
+	// Stage the same-repo ref files used by the chart.
+	refDirs, err := stageRefSources(tempDir, branchFolder, refSources, primarySource)
 	if err != nil {
 		cleanup()
 		return nil, "", nil, err
@@ -829,33 +831,74 @@ func buildRemoteChartLocalRefsRequest(
 	return newManifestRequest(&rewrittenSource), tempDir, cleanup, nil
 }
 
-// stageRefSources copies each ref source's directory into
-// <tempDir>/.refs/<refName>/ and returns a map of ref name to absolute local
-// directory. A ref source with an empty Path points at the repository root
-// (branchFolder).
-func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.ApplicationSource) (map[string]string, error) {
+// stageRefSources stages only the Helm value files and file parameters that
+// reference another source. A ref source with an empty Path still resolves
+// paths from the repository root, but unrelated repository files are not
+// copied into the streamed archive.
+func stageRefSources(tempDir, branchFolder string, refSources []v1alpha1.ApplicationSource, primarySource v1alpha1.ApplicationSource) (map[string]string, error) {
 	refDirs := make(map[string]string, len(refSources))
+	refsByName := make(map[string]v1alpha1.ApplicationSource, len(refSources))
 	for _, ref := range refSources {
-		refDir := filepath.Join(tempDir, ".refs", ref.Ref)
-		srcRefDir := filepath.Join(branchFolder, ref.Path)
-		if ref.Path == "" {
-			// Ref-only source with no path points at the repo root.
-			srcRefDir = branchFolder
+		refsByName[ref.Ref] = ref
+		refDirs[ref.Ref] = filepath.Join(tempDir, ".refs", ref.Ref)
+	}
+	if primarySource.Helm == nil {
+		return refDirs, nil
+	}
+
+	refPaths := append([]string{}, primarySource.Helm.ValueFiles...)
+	for _, fileParameter := range primarySource.Helm.FileParameters {
+		refPaths = append(refPaths, fileParameter.Path)
+	}
+	for _, refValuePath := range refPaths {
+		refName, refPath, ok := splitRefPath(refValuePath)
+		if !ok {
+			if strings.HasPrefix(refValuePath, "$") {
+				return nil, fmt.Errorf("invalid ref path %q", refValuePath)
+			}
+			continue
 		}
-		if err := copyDir(srcRefDir, refDir); err != nil {
-			return nil, fmt.Errorf("failed to copy ref source %q: %w", ref.Ref, err)
+		ref, found := refsByName[refName]
+		if !found {
+			return nil, fmt.Errorf("ref path %q references unknown ref %q", refValuePath, refName)
 		}
-		refDirs[ref.Ref] = refDir
+
+		refRoot := localRefSourceRoot(branchFolder, ref)
+		srcFile, relPath, err := resolveRefFilePath(refRoot, refPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ref path %q for source %q: %w", refValuePath, refName, err)
+		}
+		if _, err := os.Stat(srcFile); err != nil {
+			if primarySource.Helm.IgnoreMissingValueFiles && errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to inspect ref path %q from source %q: %w", refValuePath, refName, err)
+		}
+		if err := copyFile(srcFile, filepath.Join(refDirs[refName], relPath)); err != nil {
+			return nil, fmt.Errorf("failed to stage ref path %q from source %q: %w", refValuePath, refName, err)
+		}
 	}
 	return refDirs, nil
 }
 
-// rewriteRefValueFiles returns a copy of source whose Helm $ref/… value-file
-// paths are rewritten to filesystem paths relative to appDirAbs, resolved
-// against the staged ref directories in refDirs. Non-$ref value files are left
-// untouched, and a source with no Helm config is returned unchanged. The
-// returned source carries a fresh Helm copy, so the caller's source is not
-// mutated.
+func resolveRefFilePath(refRoot, refPath string) (string, string, error) {
+	if filepath.IsAbs(refPath) {
+		return "", "", errors.New("absolute paths are not allowed")
+	}
+	srcFile := filepath.Join(refRoot, refPath)
+	relPath, err := filepath.Rel(refRoot, srcFile)
+	if err != nil {
+		return "", "", err
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", "", errors.New("path escapes the ref source root")
+	}
+	return srcFile, relPath, nil
+}
+
+// rewriteRefValueFiles returns a copy of source whose Helm $ref paths are
+// rewritten to filesystem paths relative to appDirAbs. Value files and file
+// parameters that do not use refs are left untouched.
 func rewriteRefValueFiles(
 	source v1alpha1.ApplicationSource,
 	appDirAbs string,
@@ -887,6 +930,26 @@ func rewriteRefValueFiles(
 	}
 	helmCopy := *source.Helm
 	helmCopy.ValueFiles = rewritten
+	helmCopy.FileParameters = append([]v1alpha1.HelmFileParameter(nil), source.Helm.FileParameters...)
+	for i := range helmCopy.FileParameters {
+		fileParameter := &helmCopy.FileParameters[i]
+		if !strings.HasPrefix(fileParameter.Path, "$") {
+			continue
+		}
+		refName, refPath, ok := splitRefPath(fileParameter.Path)
+		if !ok {
+			continue
+		}
+		refLocalDir, known := refDirs[refName]
+		if !known {
+			return source, fmt.Errorf("file parameter %q references unknown ref %q in app %s", fileParameter.Path, refName, appLongName)
+		}
+		relPath, err := filepath.Rel(appDirAbs, filepath.Join(refLocalDir, refPath))
+		if err != nil {
+			return source, fmt.Errorf("failed to compute relative path for ref file parameter: %w", err)
+		}
+		fileParameter.Path = relPath
+	}
 	source.Helm = &helmCopy
 	return source, nil
 }

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -576,6 +576,16 @@ func TestStageRefSourcesDeduplicatesStaticPaths(t *testing.T) {
 	assert.FileExists(t, filepath.Join(refDirs["values"], "values.yaml"))
 }
 
+func TestStageRefSourcesDoesNotIgnoreMissingFileParameter(t *testing.T) {
+	_, err := stageRefSources(t.TempDir(), t.TempDir(), []v1alpha1.ApplicationSource{{Ref: "values"}}, v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			IgnoreMissingValueFiles: true,
+			FileParameters:          []v1alpha1.HelmFileParameter{{Name: "required", Path: "$values/missing.txt"}},
+		},
+	})
+	require.ErrorContains(t, err, "missing.txt")
+}
+
 func TestStageRefSourcesFallsBackForDynamicPaths(t *testing.T) {
 	branchFolder := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "environments"), 0o755))

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -562,6 +562,34 @@ func TestStageRefSourcesRejectsMalformedRefPath(t *testing.T) {
 	require.ErrorContains(t, err, "invalid ref path")
 }
 
+func TestStageRefSourcesDeduplicatesStaticPaths(t *testing.T) {
+	branchFolder := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "values.yaml"), []byte("replicas: 2\n"), 0o644))
+
+	refDirs, err := stageRefSources(t.TempDir(), branchFolder, []v1alpha1.ApplicationSource{{Ref: "values"}}, v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{
+			ValueFiles:     []string{"$values/values.yaml", "$values/values.yaml"},
+			FileParameters: []v1alpha1.HelmFileParameter{{Name: "copy", Path: "$values/values.yaml"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(refDirs["values"], "values.yaml"))
+}
+
+func TestStageRefSourcesFallsBackForDynamicPaths(t *testing.T) {
+	branchFolder := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "environments"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "environments", "my-app.yaml"), []byte("replicas: 2\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "unrelated.yaml"), []byte("present: true\n"), 0o644))
+
+	refDirs, err := stageRefSources(t.TempDir(), branchFolder, []v1alpha1.ApplicationSource{{Ref: "values"}}, v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$values/environments/$ARGOCD_APP_NAME.yaml"}},
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(refDirs["values"], "environments", "my-app.yaml"))
+	assert.FileExists(t, filepath.Join(refDirs["values"], "unrelated.yaml"), "dynamic paths must preserve full-ref staging")
+}
+
 func TestBuildManifestRequest_ExternalChart_WithRefAndPath_GH401(t *testing.T) {
 	// Exact reproduction of https://github.com/dag-andersen/argocd-diff-preview/issues/401
 	//

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -476,6 +476,9 @@ func TestBuildManifestRequest_MultiSource_LocalChart_WithRef_RewritesValueFiles(
 	// The ref-only source has no path (points at repo root), so we put the
 	// values file at the repo root level inside the branch folder.
 	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "values-prod.yaml"), []byte("replicas: 3\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "secrets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "secrets", "token.txt"), []byte("token\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "unrelated.yaml"), []byte("ignored: true\n"), 0o644))
 
 	app := makeApp(t, `
 apiVersion: argoproj.io/v1alpha1
@@ -495,6 +498,9 @@ spec:
       helm:
         valueFiles:
           - $cfg/values-prod.yaml
+        fileParameters:
+          - name: auth.token
+            path: $cfg/secrets/token.txt
 `)
 
 	contentSources, refSources, hasMultipleSources, err := splitSources(app)
@@ -526,6 +532,11 @@ spec:
 	absValueFile = filepath.Clean(absValueFile)
 	_, statErr := os.Stat(absValueFile)
 	assert.NoError(t, statErr, "rewritten value file path %q should exist on disk", absValueFile)
+	assert.NoFileExists(t, filepath.Join(streamDir, ".refs", "cfg", "unrelated.yaml"), "only referenced files should be staged")
+	require.Len(t, req.ApplicationSource.Helm.FileParameters, 1)
+	fileParameter := req.ApplicationSource.Helm.FileParameters[0]
+	assert.NotContains(t, fileParameter.Path, "$", "file parameter path must be rewritten")
+	assert.FileExists(t, filepath.Join(streamDir, "apps", "my-chart", fileParameter.Path))
 	assertDefaultProjectFields(t, req)
 }
 
@@ -539,6 +550,18 @@ spec:
 //	  "source referenced "$values", but no source has a 'ref' field defined"
 //
 // ─────────────────────────────────────────────────────────────────────────────
+func TestResolveRefFilePathRejectsTraversal(t *testing.T) {
+	_, _, err := resolveRefFilePath(t.TempDir(), "../outside.yaml")
+	require.ErrorContains(t, err, "escapes")
+}
+
+func TestStageRefSourcesRejectsMalformedRefPath(t *testing.T) {
+	_, err := stageRefSources(t.TempDir(), t.TempDir(), []v1alpha1.ApplicationSource{{Ref: "values"}}, v1alpha1.ApplicationSource{
+		Helm: &v1alpha1.ApplicationSourceHelm{ValueFiles: []string{"$values"}},
+	})
+	require.ErrorContains(t, err, "invalid ref path")
+}
+
 func TestBuildManifestRequest_ExternalChart_WithRefAndPath_GH401(t *testing.T) {
 	// Exact reproduction of https://github.com/dag-andersen/argocd-diff-preview/issues/401
 	//


### PR DESCRIPTION
## Summary
- stage only Helm `valueFiles` and `fileParameters` that use same-repository `$ref` sources instead of copying the entire ref source directory
- deduplicate repeated static ref paths across value files and file parameters
- preserve Argo CD environment substitution by falling back to one full-ref staging operation for dynamic paths such as `$values/$ARGOCD_APP_NAME.yaml`
- preserve `ignoreMissingValueFiles`, rewrite `$ref` file-parameter paths, and reject malformed or escaping ref paths
- apply scoped staging to both local content sources and locally pulled remote charts
- extend the existing `branch-5/target-2` repo-server-api integration test with a `100Ki` streamed archive limit instead of adding another integration-test execution

## Why
A root `$ref` currently copies the complete checked-out repository under `.refs/<name>` for every affected application. In the reused branch-5 fixture that repository compresses to roughly 2.8 MiB, although the chart only needs one values file.

## Validation
- `go test ./pkg/...`
- `go vet ./pkg/reposerver ./pkg/reposerverextract`
- `TEST_CASE="branch-5/target-2" go test -v -timeout 20m -run TestSingleCase ./...`

The integration test fails on the old implementation because the archive exceeds the configured `100Ki` repo-server limit. With this change it passes using roughly 4.6 KiB per branch and keeps the existing golden output unchanged.