### PR TITLE
Fix | Deduplicate resources in apps with no destination ns

### DIFF
--- a/integration-test/branch-19/target/output.html
+++ b/integration-test/branch-19/target/output.html
@@ -59,61 +59,13 @@ pre {
 <h1>Argo CD Diff Preview</h1>
 
 <p>Summary:</p>
-<pre>Modified (6):
-± app-b (+25)
+<pre>Modified (4):
 ± cluster-a-cluster-rbac (-25)
-± cluster-b-cluster-rbac (+12)
 ± kustomize-build-options (+2|-2)
 ± owner-a (-12)
 ± owner-b (+12)</pre>
 
 <div class="diffs">
-<details>
-<summary>
-app-b (examples/resource-application-boundary/applicationset.yaml)
-</summary>
-
-<h4 class="resource_header">ClusterRole: app-b-node-reader</h4>
-<div class="diff_container">
-<table>
-
-	<tr class="added_line"><td><pre>+apiVersion: rbac.authorization.k8s.io/v1</pre></td></tr>
-	<tr class="added_line"><td><pre>+kind: ClusterRole</pre></td></tr>
-	<tr class="added_line"><td><pre>+metadata:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: app-b-node-reader</pre></td></tr>
-	<tr class="added_line"><td><pre>+rules:</pre></td></tr>
-	<tr class="added_line"><td><pre>+- apiGroups:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  - &#34;&#34;</pre></td></tr>
-	<tr class="added_line"><td><pre>+  resources:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  - nodes</pre></td></tr>
-	<tr class="added_line"><td><pre>+  verbs:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  - get</pre></td></tr>
-	<tr class="added_line"><td><pre>+  - list</pre></td></tr>
-	<tr class="added_line"><td><pre>+  - watch</pre></td></tr>
-</table>
-</div>
-
-<h4 class="resource_header">ClusterRoleBinding: app-b-node-reader</h4>
-<div class="diff_container">
-<table>
-
-	<tr class="added_line"><td><pre>+apiVersion: rbac.authorization.k8s.io/v1</pre></td></tr>
-	<tr class="added_line"><td><pre>+kind: ClusterRoleBinding</pre></td></tr>
-	<tr class="added_line"><td><pre>+metadata:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: app-b-node-reader</pre></td></tr>
-	<tr class="added_line"><td><pre>+roleRef:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  apiGroup: rbac.authorization.k8s.io</pre></td></tr>
-	<tr class="added_line"><td><pre>+  kind: ClusterRole</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: app-b-node-reader</pre></td></tr>
-	<tr class="added_line"><td><pre>+subjects:</pre></td></tr>
-	<tr class="added_line"><td><pre>+- apiGroup: rbac.authorization.k8s.io</pre></td></tr>
-	<tr class="added_line"><td><pre>+  kind: Group</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: app-b-readers</pre></td></tr>
-</table>
-</div>
-
-</details>
-
 <details>
 <summary>
 cluster-a-cluster-rbac (examples/cluster-rbac-repro/deployment-config/applicationsets/cluster-rbac.yaml)
@@ -155,32 +107,6 @@ cluster-a-cluster-rbac (examples/cluster-rbac-repro/deployment-config/applicatio
 	<tr class="removed_line"><td><pre>-- apiGroup: rbac.authorization.k8s.io</pre></td></tr>
 	<tr class="removed_line"><td><pre>-  kind: Group</pre></td></tr>
 	<tr class="removed_line"><td><pre>-  name: aks:jwt:platform-cluster:system:serviceaccount:automation:automation-agent</pre></td></tr>
-</table>
-</div>
-
-</details>
-
-<details>
-<summary>
-cluster-b-cluster-rbac (examples/cluster-rbac-repro/deployment-config/applicationsets/cluster-rbac.yaml)
-</summary>
-
-<h4 class="resource_header">ClusterRoleBinding: sympozium-agent-view</h4>
-<div class="diff_container">
-<table>
-
-	<tr class="added_line"><td><pre>+apiVersion: rbac.authorization.k8s.io/v1</pre></td></tr>
-	<tr class="added_line"><td><pre>+kind: ClusterRoleBinding</pre></td></tr>
-	<tr class="added_line"><td><pre>+metadata:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: sympozium-agent-view</pre></td></tr>
-	<tr class="added_line"><td><pre>+roleRef:</pre></td></tr>
-	<tr class="added_line"><td><pre>+  apiGroup: rbac.authorization.k8s.io</pre></td></tr>
-	<tr class="added_line"><td><pre>+  kind: ClusterRole</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: view</pre></td></tr>
-	<tr class="added_line"><td><pre>+subjects:</pre></td></tr>
-	<tr class="added_line"><td><pre>+- apiGroup: rbac.authorization.k8s.io</pre></td></tr>
-	<tr class="added_line"><td><pre>+  kind: Group</pre></td></tr>
-	<tr class="added_line"><td><pre>+  name: oidc:jwt:platform-cluster:system:serviceaccount:automation:automation-agent</pre></td></tr>
 </table>
 </div>
 

--- a/integration-test/branch-19/target/output.md
+++ b/integration-test/branch-19/target/output.md
@@ -2,51 +2,12 @@
 
 Summary:
 ```yaml
-Modified (6):
-± app-b (+25)
+Modified (4):
 ± cluster-a-cluster-rbac (-25)
-± cluster-b-cluster-rbac (+12)
 ± kustomize-build-options (+2|-2)
 ± owner-a (-12)
 ± owner-b (+12)
 ```
-
-<details>
-<summary>app-b (examples/resource-application-boundary/applicationset.yaml)</summary>
-<br>
-
-#### ClusterRole: app-b-node-reader
-```diff
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRole
-+metadata:
-+  name: app-b-node-reader
-+rules:
-+- apiGroups:
-+  - ""
-+  resources:
-+  - nodes
-+  verbs:
-+  - get
-+  - list
-+  - watch
-```
-#### ClusterRoleBinding: app-b-node-reader
-```diff
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRoleBinding
-+metadata:
-+  name: app-b-node-reader
-+roleRef:
-+  apiGroup: rbac.authorization.k8s.io
-+  kind: ClusterRole
-+  name: app-b-node-reader
-+subjects:
-+- apiGroup: rbac.authorization.k8s.io
-+  kind: Group
-+  name: app-b-readers
-```
-</details>
 
 <details>
 <summary>cluster-a-cluster-rbac (examples/cluster-rbac-repro/deployment-config/applicationsets/cluster-rbac.yaml)</summary>
@@ -82,27 +43,6 @@ Modified (6):
 -- apiGroup: rbac.authorization.k8s.io
 -  kind: Group
 -  name: aks:jwt:platform-cluster:system:serviceaccount:automation:automation-agent
-```
-</details>
-
-<details>
-<summary>cluster-b-cluster-rbac (examples/cluster-rbac-repro/deployment-config/applicationsets/cluster-rbac.yaml)</summary>
-<br>
-
-#### ClusterRoleBinding: sympozium-agent-view
-```diff
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRoleBinding
-+metadata:
-+  name: sympozium-agent-view
-+roleRef:
-+  apiGroup: rbac.authorization.k8s.io
-+  kind: ClusterRole
-+  name: view
-+subjects:
-+- apiGroup: rbac.authorization.k8s.io
-+  kind: Group
-+  name: oidc:jwt:platform-cluster:system:serviceaccount:automation:automation-agent
 ```
 </details>
 

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -430,10 +430,6 @@ func normalizeNamespaces(
 	clusterScopedResources map[schema.GroupKind]bool,
 	appName string,
 ) ([]unstructured.Unstructured, error) {
-	if destNamespace == "" {
-		return manifests, nil
-	}
-
 	// Convert to pointer slice for DeduplicateTargetObjects
 	ptrManifests := make([]*unstructured.Unstructured, len(manifests))
 	for i := range manifests {

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -215,6 +215,29 @@ func TestNormalizeNamespacesPreservesSameNamedUnknownResources(t *testing.T) {
 	assert.ElementsMatch(t, []string{"ns-a", "ns-b", "ns-c"}, actualNamespaces)
 }
 
+func TestNormalizeNamespacesDeduplicatesClusterScopedResourcesWithoutDestinationNamespace(t *testing.T) {
+	first := unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": "node-reader",
+		},
+		"rules": []any{map[string]any{"verbs": []any{"get"}}},
+	}}
+	last := first.DeepCopy()
+	last.Object["rules"] = []any{map[string]any{"verbs": []any{"get", "list"}}}
+
+	result, err := normalizeNamespaces(
+		[]unstructured.Unstructured{first, *last},
+		"",
+		map[schema.GroupKind]bool{{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: true},
+		"test-app",
+	)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, last.Object, result[0].Object, "Argo CD deduplication should keep the last resource")
+}
+
 func TestResourceInfoProviderDefaultsUnknownKindsToNamespaced(t *testing.T) {
 	provider := &resourceInfoProvider{clusterScopedByGk: map[schema.GroupKind]bool{
 		{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: true,

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -1264,10 +1264,6 @@ func normalizeNamespaces(
 	clusterScopedResources map[schema.GroupKind]bool,
 	appName string,
 ) ([]unstructured.Unstructured, error) {
-	if destNamespace == "" {
-		return manifests, nil
-	}
-
 	ptrManifests := make([]*unstructured.Unstructured, len(manifests))
 	for i := range manifests {
 		ptrManifests[i] = &manifests[i]

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
 
@@ -78,6 +79,29 @@ func assertDefaultProjectFields(t *testing.T, req *repoapiclient.ManifestRequest
 	t.Helper()
 	assert.Equal(t, "default", req.ProjectName, "project name must match the patched application project")
 	assert.Equal(t, []string{"*"}, req.ProjectSourceRepos, "source repos must be permissive so helm build errors are not masked as permission errors")
+}
+
+func TestNormalizeNamespacesDeduplicatesClusterScopedResourcesWithoutDestinationNamespace(t *testing.T) {
+	first := unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": "node-reader",
+		},
+		"rules": []any{map[string]any{"verbs": []any{"get"}}},
+	}}
+	last := first.DeepCopy()
+	last.Object["rules"] = []any{map[string]any{"verbs": []any{"get", "list"}}}
+
+	result, err := normalizeNamespaces(
+		[]unstructured.Unstructured{first, *last},
+		"",
+		map[schema.GroupKind]bool{{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"}: true},
+		"test-app",
+	)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, last.Object, result[0].Object, "Argo CD deduplication should keep the last resource")
 }
 
 func testRepoSelector(t *testing.T, repo string) *repository.Selector {


### PR DESCRIPTION
## Summary

- Run Argo CD resource normalization and deduplication when an Application has no destination namespace
- Preserve Argo CD's repeated-resource behavior for cluster-scoped resources
- Add regression tests for empty destination namespaces
- Update branch-19 golden output to exclude repeated resources within an Application

## Problem

The manifest extraction paths returned early when `spec.destination.namespace` was empty. This skipped Argo CD's `DeduplicateTargetObjects` processing.

Applications containing cluster-scoped resources commonly omit the destination namespace. If such an Application generated the same resource more than once, the duplicate manifests reached the diff engine and were incorrectly reported as additions.

## Fix

Always call `DeduplicateTargetObjects`, including when the destination namespace is empty.

Argo CD then:

- Normalizes resource namespaces according to resource scope
- Deduplicates resources by group, kind, namespace, and name
- Keeps the last repeated resource
- Reports repeated-resource warnings

This remains scoped to resources within one Application. Resources belonging to different Applications are not deduplicated against each other.

## Testing

- `go test ./pkg/extract/... ./pkg/reposerverextract/...`
- `TEST_CASE=\"branch-19/target\" go test -v -timeout 20m -run TestSingleCase -update ./...`
- `TEST_CASE=\"branch-19/target\" go test -v -timeout 20m -run TestSingleCase ./...`